### PR TITLE
Fix race condition for truncated words at end of recording

### DIFF
--- a/config.py
+++ b/config.py
@@ -244,7 +244,11 @@ TRANSCRIBING_TIMEOUT = 45.0  # Sekunden (Deepgram + Refine sollten < 30s dauern)
 AUDIO_QUEUE_POLL_INTERVAL = 0.1  # Sekunden zwischen Queue-Polls
 SEND_MEDIA_TIMEOUT = 5.0  # Max. Wartezeit für WebSocket send_media()
 FORWARDER_THREAD_JOIN_TIMEOUT = 0.5  # Timeout beim Beenden des Forwarder-Threads
-DRAIN_POLL_INTERVAL = 0.01  # Queue-Poll-Interval während Drain (10ms)
+
+# Drain-Konfiguration: Leeren der Audio-Queue nach Aufnahme-Stop
+DRAIN_POLL_INTERVAL = 0.01  # Timeout pro Queue.get() während Drain (10ms)
+DRAIN_MAX_DURATION = 0.2  # Maximale Drain-Dauer als Safety-Limit (200ms)
+DRAIN_EMPTY_THRESHOLD = 2  # Anzahl leerer Polls bevor Drain beendet wird
 
 # LLM-Refine Timeout: Maximale Wartezeit für API-Calls
 # Verhindert "hängende" Requests bei Netzwerkproblemen
@@ -330,6 +334,8 @@ __all__ = [
     "SEND_MEDIA_TIMEOUT",
     "FORWARDER_THREAD_JOIN_TIMEOUT",
     "DRAIN_POLL_INTERVAL",
+    "DRAIN_MAX_DURATION",
+    "DRAIN_EMPTY_THRESHOLD",
     # Models
     "DEFAULT_API_MODEL",
     "DEFAULT_LOCAL_MODEL",

--- a/config.py
+++ b/config.py
@@ -190,7 +190,7 @@ def get_input_device() -> tuple[int | None, int]:
 
 INTERIM_THROTTLE_MS = 150  # Max. Update-Rate für Interim-File (Menübar pollt 200ms)
 FINALIZE_TIMEOUT = (
-    1.0  # Warten auf finale Transkripte (Deepgram antwortet meist in 300-500ms)
+    2.0  # Warten auf finale Transkripte (erhöht für Windows/Netzwerk-Latenz)
 )
 DEEPGRAM_WS_URL = "wss://api.deepgram.com/v1/listen"
 
@@ -244,7 +244,6 @@ TRANSCRIBING_TIMEOUT = 45.0  # Sekunden (Deepgram + Refine sollten < 30s dauern)
 AUDIO_QUEUE_POLL_INTERVAL = 0.1  # Sekunden zwischen Queue-Polls
 SEND_MEDIA_TIMEOUT = 5.0  # Max. Wartezeit für WebSocket send_media()
 FORWARDER_THREAD_JOIN_TIMEOUT = 0.5  # Timeout beim Beenden des Forwarder-Threads
-DRAIN_WINDOW_DURATION = 0.05  # Drain-Fenster nach arm_event.clear() (50ms = 2-3 Callback-Zyklen)
 DRAIN_POLL_INTERVAL = 0.01  # Queue-Poll-Interval während Drain (10ms)
 
 # LLM-Refine Timeout: Maximale Wartezeit für API-Calls
@@ -330,7 +329,6 @@ __all__ = [
     "AUDIO_QUEUE_POLL_INTERVAL",
     "SEND_MEDIA_TIMEOUT",
     "FORWARDER_THREAD_JOIN_TIMEOUT",
-    "DRAIN_WINDOW_DURATION",
     "DRAIN_POLL_INTERVAL",
     # Models
     "DEFAULT_API_MODEL",

--- a/providers/deepgram_stream.py
+++ b/providers/deepgram_stream.py
@@ -37,7 +37,6 @@ from config import (
     DEEPGRAM_WS_URL,
     DEFAULT_DEEPGRAM_MODEL,
     DRAIN_POLL_INTERVAL,
-    DRAIN_WINDOW_DURATION,
     FINALIZE_TIMEOUT,
     FORWARDER_THREAD_JOIN_TIMEOUT,
     INT16_MAX,
@@ -446,25 +445,28 @@ def _init_warm_stream(
                 break
 
         # Audio-Callback stoppen und Queue drainieren
-        # arm_event.clear() signalisiert dem Callback, keine neuen Chunks zu schreiben.
-        # Wir drainieren dann für DRAIN_WINDOW_DURATION, um auch Chunks zu erfassen,
-        # die der Callback noch zwischen is_set()-Prüfung und put_nowait() geschrieben
-        # hat (TOCTOU).
+        # 1. arm_event.clear() signalisiert dem Callback, keine neuen Chunks zu schreiben
+        # 2. Kurze Pause gibt dem Callback Zeit, seinen aktuellen Schreibvorgang
+        #    abzuschließen (TOCTOU: Callback hat is_set() bereits geprüft)
+        # 3. Queue komplett leeren bis sie leer bleibt
         warm_source.arm_event.clear()
+        time.sleep(DRAIN_POLL_INTERVAL)  # Warten auf laufenden Callback
 
         drained = 0
-        drain_deadline = time.monotonic() + DRAIN_WINDOW_DURATION
-        while time.monotonic() < drain_deadline:
+        empty_count = 0
+        while empty_count < 2:  # 2x leer = sicher fertig
             try:
                 chunk = warm_source.audio_queue.get(timeout=DRAIN_POLL_INTERVAL)
                 loop.call_soon_threadsafe(audio_queue.put_nowait, chunk)
                 drained += 1
+                empty_count = 0  # Reset bei erfolgreichem Chunk
             except queue.Empty:
-                continue
+                empty_count += 1
             except RuntimeError:
                 # Event-Loop bereits geschlossen
                 logger.debug(f"[{session_id}] Event-Loop geschlossen, Drain abgebrochen")
                 break
+
         if drained > 0:
             logger.debug(f"[{session_id}] Warm-Stream: {drained} Rest-Chunks geleert")
 


### PR DESCRIPTION
Simplified and corrected drain logic:
1. arm_event.clear() signals callback to stop
2. Short sleep (10ms) lets any in-flight callback complete
3. Single drain loop waits for 2 consecutive empty polls

Previous approach had timing hole: get_nowait() after time window
could miss chunks written by callback during the check.

Also:
- Increase FINALIZE_TIMEOUT from 1.0s to 2.0s for network latency
- Remove unused DRAIN_WINDOW_DURATION constant

## Summary by Sourcery

Improve audio queue draining to avoid race conditions when stopping the Deepgram warm stream and waiting for final transcripts.

Bug Fixes:
- Eliminate a timing hole in the warm stream drain logic that could drop audio chunks and truncate words at the end of recordings.

Enhancements:
- Simplify and make the warm stream drain loop more robust by using a short post-stop delay and draining until the queue is consistently empty.
- Increase the finalize timeout for receiving final Deepgram transcripts to better tolerate higher network latency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased transcript finalization timeout to better handle network and Windows delays.
  * Improved queue draining for more reliable asynchronous stream shutdown, adding a max-duration safety and empty-poll threshold to prevent hangs.

* **New Features**
  * Added configurable drain controls (max duration and empty-poll threshold) for finer tuning of stream draining behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->