### PR TITLE
perf: reduce macOS dictation latency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,10 @@ DEEPGRAM_API_KEY=...
 # Windows: Deepgram-Verbindung für die nächste Aufnahme vorab öffnen.
 PULSESCRIBE_DEEPGRAM_WARM_WEBSOCKET=true
 PULSESCRIBE_DEEPGRAM_KEEPALIVE_INTERVAL_SECONDS=3
+# Harte Grenzen für blockierte WebSocket-Control-Sends (Änderung benötigt Neustart).
+# PULSESCRIBE_DEEPGRAM_FINALIZE_SEND_TIMEOUT=1.0
+# PULSESCRIBE_DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT=0.5
+# PULSESCRIBE_DEEPGRAM_KEEPALIVE_SEND_TIMEOUT=1.0
 
 # Windows-Latenzprofil: safe (Default) oder snappy.
 # Snappy nutzt kürzere Capture-/Finalize-Puffer; safe bevorzugt maximale Endwort-Sicherheit.
@@ -77,6 +81,13 @@ PULSESCRIBE_DEEPGRAM_KEEPALIVE_INTERVAL_SECONDS=3
 # Windows-Latenzdiagnose: schreibt privacy-sichere Timing-Events nach
 # ~/.pulsescribe/logs/windows_latency.jsonl und in pulsescribe.log.
 # PULSESCRIBE_WINDOWS_LATENCY_DIAGNOSTICS=false
+
+# macOS-End-to-End-Latenzdiagnose: privacy-sichere Timing-Events ohne Audio,
+# Transkript-, Clipboard-, Hotkey- oder App-Inhalte. JSONL-Default:
+# ~/.pulsescribe/logs/macos_latency.jsonl
+# PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS=false
+# PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_FILE=true
+# PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_PATH=~/.pulsescribe/logs/macos_latency.jsonl
 
 # Groq API (für --mode groq und --refine mit groq)
 # Extrem schnelle Whisper-Inferenz (~300x Echtzeit): https://console.groq.com

--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ Vermeidet Duplikation zwischen Modulen.
 """
 
 import logging
+import math
 import os
 import tempfile
 from collections.abc import Callable
@@ -338,6 +339,9 @@ def _get_bounded_float_env(
 ) -> float:
     """Liest Float-ENV und begrenzt auf einen sinnvollen Bereich."""
     value = _get_float_env(name, default)
+    if math.isnan(value):
+        logger.warning(f"Wert für {name}=NaN ungültig, verwende Default {default}")
+        return default
     if value < min_value:
         logger.warning(
             f"Wert für {name}={value} zu klein, verwende Minimum {min_value}"
@@ -409,6 +413,24 @@ DEEPGRAM_KEEPALIVE_INTERVAL_SECONDS = _get_bounded_float_env(
     min_value=1.0,
     max_value=8.0,
 )  # Deepgram beendet Streams nach ~10s ohne Audio/KeepAlive.
+DEEPGRAM_FINALIZE_SEND_TIMEOUT = _get_bounded_float_env(
+    "PULSESCRIBE_DEEPGRAM_FINALIZE_SEND_TIMEOUT",
+    1.0,
+    min_value=0.05,
+    max_value=10.0,
+)
+DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT = _get_bounded_float_env(
+    "PULSESCRIBE_DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT",
+    0.5,
+    min_value=0.05,
+    max_value=10.0,
+)
+DEEPGRAM_KEEPALIVE_SEND_TIMEOUT = _get_bounded_float_env(
+    "PULSESCRIBE_DEEPGRAM_KEEPALIVE_SEND_TIMEOUT",
+    1.0,
+    min_value=0.05,
+    max_value=10.0,
+)
 
 
 def get_windows_stop_grace_seconds() -> float:
@@ -607,6 +629,9 @@ __all__ = [
     "DEEPGRAM_TAIL_PADDING_SECONDS",
     "DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS",
     "DEEPGRAM_KEEPALIVE_INTERVAL_SECONDS",
+    "DEEPGRAM_FINALIZE_SEND_TIMEOUT",
+    "DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT",
+    "DEEPGRAM_KEEPALIVE_SEND_TIMEOUT",
     "WINDOWS_STOP_GRACE_SECONDS",
     "get_windows_adaptive_stop_tail_enabled",
     "get_windows_paste_sync_seconds",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -168,8 +168,11 @@ Both hotkeys can be active simultaneously.
 | `PULSESCRIBE_DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS` | `0`-e.g. `1.0` seconds     | `0.10` (`snappy`, default), `0.25` (`safe`) | Extra wait after Deepgram acknowledges Finalize without a transcript, in case the final transcript arrives late. Ends early as soon as a late final transcript arrives. Applies to Deepgram streaming on all platforms; requires restart. |
 | `PULSESCRIBE_DEEPGRAM_WARM_WEBSOCKET`      | `true`, `false`                     | `true` | Preconnect the next Deepgram streaming session on Windows. Each socket is consumed once and replaced after `CloseStream`. |
 | `PULSESCRIBE_DEEPGRAM_KEEPALIVE_INTERVAL_SECONDS` | `1`-`8` seconds              | `3` | KeepAlive interval for an unused preconnected Deepgram socket. |
+| `PULSESCRIBE_DEEPGRAM_FINALIZE_SEND_TIMEOUT` | `0.05`-`10` seconds | `1.0` | Hard deadline for sending Deepgram `Finalize`. A timeout skips the response wait and continues with bounded close. |
+| `PULSESCRIBE_DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT` | `0.05`-`10` seconds | `0.5` | Hard deadline for sending `CloseStream`; listener cleanup still runs after a timeout. |
+| `PULSESCRIBE_DEEPGRAM_KEEPALIVE_SEND_TIMEOUT` | `0.05`-`10` seconds | `1.0` | Hard deadline for a warm-socket KeepAlive; timed-out sockets are discarded and replenished. |
 
-Set stop grace to `0` to disable the extra tail capture. Changing `PULSESCRIBE_WINDOWS_LATENCY_PRESET`, `PULSESCRIBE_WINDOWS_RESPONSIVENESS_BOOST`, `PULSESCRIBE_DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS`, or the KeepAlive interval requires restarting PulseScribe; the other Windows values above are read when settings reload.
+Set stop grace to `0` to disable the extra tail capture. Changing `PULSESCRIBE_WINDOWS_LATENCY_PRESET`, `PULSESCRIBE_WINDOWS_RESPONSIVENESS_BOOST`, `PULSESCRIBE_DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS`, the KeepAlive interval, or a Deepgram control-send timeout requires restarting PulseScribe; the other Windows values above are read when settings reload.
 
 ### Windows Latency Diagnostics
 
@@ -179,6 +182,16 @@ Set stop grace to `0` to disable the extra tail capture. Changing `PULSESCRIBE_W
 | `PULSESCRIBE_WINDOWS_LATENCY_DIAGNOSTICS_FILE` | `true`, `false` | `true` when diagnostics are enabled | Also append structured JSONL to `~/.pulsescribe/logs/windows_latency.jsonl`. |
 
 The diagnostics record event names, durations, mode, and success flags only — no audio and no transcript text.
+
+### macOS Latency Diagnostics
+
+| Variable                                      | Values          | Default | Description                               |
+| --------------------------------------------- | --------------- | ------- | ----------------------------------------- |
+| `PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS`       | `true`, `false` | `false` | Log privacy-safe end-to-end timings for accepted macOS recording runs. |
+| `PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_FILE`  | `true`, `false` | `true` when diagnostics are enabled | Append structured JSONL to `~/.pulsescribe/logs/macos_latency.jsonl`. |
+| `PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_PATH`  | file path       | default JSONL path | Override the JSONL destination. |
+
+The macOS trace contains monotonic relative timings, mode, streaming flags, outcome, and numeric/boolean provider metadata. It excludes audio, transcript and clipboard text, prompts, hotkeys, application names, paths, and credentials. Stable `durations_ms` fields can be aggregated directly into P50/P95 values.
 
 ### RTF (Real-Time Factor)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -168,9 +168,9 @@ Both hotkeys can be active simultaneously.
 | `PULSESCRIBE_DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS` | `0`-e.g. `1.0` seconds     | `0.10` (`snappy`, default), `0.25` (`safe`) | Extra wait after Deepgram acknowledges Finalize without a transcript, in case the final transcript arrives late. Ends early as soon as a late final transcript arrives. Applies to Deepgram streaming on all platforms; requires restart. |
 | `PULSESCRIBE_DEEPGRAM_WARM_WEBSOCKET`      | `true`, `false`                     | `true` | Preconnect the next Deepgram streaming session on Windows. Each socket is consumed once and replaced after `CloseStream`. |
 | `PULSESCRIBE_DEEPGRAM_KEEPALIVE_INTERVAL_SECONDS` | `1`-`8` seconds              | `3` | KeepAlive interval for an unused preconnected Deepgram socket. |
-| `PULSESCRIBE_DEEPGRAM_FINALIZE_SEND_TIMEOUT` | `0.05`-`10` seconds | `1.0` | Hard deadline for sending Deepgram `Finalize`. A timeout skips the response wait and continues with bounded close. |
-| `PULSESCRIBE_DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT` | `0.05`-`10` seconds | `0.5` | Hard deadline for sending `CloseStream`; listener cleanup still runs after a timeout. |
-| `PULSESCRIBE_DEEPGRAM_KEEPALIVE_SEND_TIMEOUT` | `0.05`-`10` seconds | `1.0` | Hard deadline for a warm-socket KeepAlive; timed-out sockets are discarded and replenished. |
+| `PULSESCRIBE_DEEPGRAM_FINALIZE_SEND_TIMEOUT` | `0.05`-`10` seconds | `1.0` | Hard deadline for sending Deepgram `Finalize`. A timeout skips the response wait and closes the connection without another control send. Applies to Deepgram streaming on all platforms. |
+| `PULSESCRIBE_DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT` | `0.05`-`10` seconds | `0.5` | Hard deadline for sending `CloseStream`; listener cleanup still runs after a timeout. Applies to Deepgram streaming on all platforms. |
+| `PULSESCRIBE_DEEPGRAM_KEEPALIVE_SEND_TIMEOUT` | `0.05`-`10` seconds | `1.0` | Hard deadline for a warm-socket KeepAlive; timed-out sockets are discarded and replenished. Applies wherever warm Deepgram sockets are enabled. |
 
 Set stop grace to `0` to disable the extra tail capture. Changing `PULSESCRIBE_WINDOWS_LATENCY_PRESET`, `PULSESCRIBE_WINDOWS_RESPONSIVENESS_BOOST`, `PULSESCRIBE_DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS`, the KeepAlive interval, or a Deepgram control-send timeout requires restarting PulseScribe; the other Windows values above are read when settings reload.
 

--- a/docs/KONFIGURATION.md
+++ b/docs/KONFIGURATION.md
@@ -161,9 +161,9 @@ Beide Hotkeys können gleichzeitig aktiv sein.
 | `PULSESCRIBE_DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS` | `0`-z.B. `1.0` Sekunden    | `0.10` (`snappy`, Default), `0.25` (`safe`) | Zusatzfenster, wenn Deepgram Finalize ohne Transkript quittiert und das finale Transkript später eintreffen könnte. Endet vorzeitig, sobald ein spätes Final-Transkript ankommt. Gilt für Deepgram-Streaming auf allen Plattformen; benötigt Neustart. |
 | `PULSESCRIBE_DEEPGRAM_WARM_WEBSOCKET`      | `true`, `false`                     | `true` | Verbindet unter Windows die nächste Deepgram-Streaming-Session vorab. Jeder Socket wird einmal genutzt und nach `CloseStream` ersetzt. |
 | `PULSESCRIBE_DEEPGRAM_KEEPALIVE_INTERVAL_SECONDS` | `1`-`8` Sekunden             | `3` | KeepAlive-Intervall für einen ungenutzten vorgewärmten Deepgram-Socket. |
-| `PULSESCRIBE_DEEPGRAM_FINALIZE_SEND_TIMEOUT` | `0.05`-`10` Sekunden | `1.0` | Harte Grenze für das Senden von `Finalize`. Bei Timeout wird der Ack-Wait übersprungen und mit dem begrenzten Close fortgefahren. |
-| `PULSESCRIBE_DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT` | `0.05`-`10` Sekunden | `0.5` | Harte Grenze für `CloseStream`; der Listener-Cleanup läuft auch nach einem Timeout. |
-| `PULSESCRIBE_DEEPGRAM_KEEPALIVE_SEND_TIMEOUT` | `0.05`-`10` Sekunden | `1.0` | Harte Grenze für Warm-Socket-KeepAlive; betroffene Sockets werden verworfen und ersetzt. |
+| `PULSESCRIBE_DEEPGRAM_FINALIZE_SEND_TIMEOUT` | `0.05`-`10` Sekunden | `1.0` | Harte Grenze für das Senden von `Finalize`. Bei Timeout wird der Ack-Wait übersprungen und die Verbindung ohne weiteren Control-Send geschlossen. Gilt für Deepgram-Streaming auf allen Plattformen. |
+| `PULSESCRIBE_DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT` | `0.05`-`10` Sekunden | `0.5` | Harte Grenze für `CloseStream`; der Listener-Cleanup läuft auch nach einem Timeout. Gilt für Deepgram-Streaming auf allen Plattformen. |
+| `PULSESCRIBE_DEEPGRAM_KEEPALIVE_SEND_TIMEOUT` | `0.05`-`10` Sekunden | `1.0` | Harte Grenze für Warm-Socket-KeepAlive; betroffene Sockets werden verworfen und ersetzt. Gilt überall, wo vorgewärmte Deepgram-Sockets aktiviert sind. |
 
 Mit `0` lässt sich der zusätzliche Nachlauf deaktivieren. Änderungen an `PULSESCRIBE_WINDOWS_LATENCY_PRESET`, `PULSESCRIBE_WINDOWS_RESPONSIVENESS_BOOST`, `PULSESCRIBE_DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS`, dem KeepAlive-Intervall oder einem Deepgram-Control-Send-Timeout benötigen einen Neustart; die übrigen Windows-Werte oben werden beim Settings-Reload gelesen.
 

--- a/docs/KONFIGURATION.md
+++ b/docs/KONFIGURATION.md
@@ -161,8 +161,11 @@ Beide Hotkeys können gleichzeitig aktiv sein.
 | `PULSESCRIBE_DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS` | `0`-z.B. `1.0` Sekunden    | `0.10` (`snappy`, Default), `0.25` (`safe`) | Zusatzfenster, wenn Deepgram Finalize ohne Transkript quittiert und das finale Transkript später eintreffen könnte. Endet vorzeitig, sobald ein spätes Final-Transkript ankommt. Gilt für Deepgram-Streaming auf allen Plattformen; benötigt Neustart. |
 | `PULSESCRIBE_DEEPGRAM_WARM_WEBSOCKET`      | `true`, `false`                     | `true` | Verbindet unter Windows die nächste Deepgram-Streaming-Session vorab. Jeder Socket wird einmal genutzt und nach `CloseStream` ersetzt. |
 | `PULSESCRIBE_DEEPGRAM_KEEPALIVE_INTERVAL_SECONDS` | `1`-`8` Sekunden             | `3` | KeepAlive-Intervall für einen ungenutzten vorgewärmten Deepgram-Socket. |
+| `PULSESCRIBE_DEEPGRAM_FINALIZE_SEND_TIMEOUT` | `0.05`-`10` Sekunden | `1.0` | Harte Grenze für das Senden von `Finalize`. Bei Timeout wird der Ack-Wait übersprungen und mit dem begrenzten Close fortgefahren. |
+| `PULSESCRIBE_DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT` | `0.05`-`10` Sekunden | `0.5` | Harte Grenze für `CloseStream`; der Listener-Cleanup läuft auch nach einem Timeout. |
+| `PULSESCRIBE_DEEPGRAM_KEEPALIVE_SEND_TIMEOUT` | `0.05`-`10` Sekunden | `1.0` | Harte Grenze für Warm-Socket-KeepAlive; betroffene Sockets werden verworfen und ersetzt. |
 
-Mit `0` lässt sich der zusätzliche Nachlauf deaktivieren. Änderungen an `PULSESCRIBE_WINDOWS_LATENCY_PRESET`, `PULSESCRIBE_WINDOWS_RESPONSIVENESS_BOOST`, `PULSESCRIBE_DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS` oder dem KeepAlive-Intervall benötigen einen Neustart; die übrigen Windows-Werte oben werden beim Settings-Reload gelesen.
+Mit `0` lässt sich der zusätzliche Nachlauf deaktivieren. Änderungen an `PULSESCRIBE_WINDOWS_LATENCY_PRESET`, `PULSESCRIBE_WINDOWS_RESPONSIVENESS_BOOST`, `PULSESCRIBE_DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS`, dem KeepAlive-Intervall oder einem Deepgram-Control-Send-Timeout benötigen einen Neustart; die übrigen Windows-Werte oben werden beim Settings-Reload gelesen.
 
 ### Windows-Latenzdiagnose
 
@@ -172,6 +175,16 @@ Mit `0` lässt sich der zusätzliche Nachlauf deaktivieren. Änderungen an `PULS
 | `PULSESCRIBE_WINDOWS_LATENCY_DIAGNOSTICS_FILE` | `true`, `false` | `true`, wenn Diagnose aktiv ist | Schreibt zusätzlich strukturierte JSONL-Daten nach `~/.pulsescribe/logs/windows_latency.jsonl`. |
 
 Die Diagnose enthält nur Event-Namen, Dauern, Modus und Erfolgsflags – kein Audio und keinen Transkripttext.
+
+### macOS-Latenzdiagnose
+
+| Variable                                      | Werte           | Default | Beschreibung                              |
+| --------------------------------------------- | --------------- | ------- | ----------------------------------------- |
+| `PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS`       | `true`, `false` | `false` | Schreibt privacy-sichere End-to-End-Timings für akzeptierte macOS-Aufnahmen. |
+| `PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_FILE`  | `true`, `false` | `true`, wenn Diagnose aktiv ist | Schreibt strukturierte JSONL-Daten nach `~/.pulsescribe/logs/macos_latency.jsonl`. |
+| `PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_PATH`  | Dateipfad       | Standard-JSONL-Pfad | Überschreibt das JSONL-Ziel. |
+
+Der macOS-Trace enthält monotone relative Zeiten, Modus, Streaming-Flag, Ergebnis und numerische/Bool-Provider-Metadaten. Audio, Transkript- und Clipboard-Text, Prompts, Hotkeys, App-Namen, Pfade und Zugangsdaten werden ausgeschlossen. Die stabilen `durations_ms`-Felder lassen sich direkt zu P50/P95 aggregieren.
 
 ---
 

--- a/providers/deepgram_stream.py
+++ b/providers/deepgram_stream.py
@@ -1674,6 +1674,7 @@ async def _graceful_shutdown_sequence(
     _emit_latency_event(latency_event_callback, "deepgram_finalize_send")
     t_finalize_start = time.perf_counter()
     finalize_sent = False
+    control_connection_usable = True
     try:
         await _send_control_with_timeout(
             connection,
@@ -1682,6 +1683,9 @@ async def _graceful_shutdown_sequence(
         )
         finalize_sent = True
     except asyncio.TimeoutError:
+        # asyncio.wait_for cancels send_control. WebSocket writes aren't safe to
+        # reuse after cancellation, so leave closure to the connection context.
+        control_connection_usable = False
         logger.warning(
             f"[{session_id}] Finalize-Send Timeout nach "
             f"{DEEPGRAM_FINALIZE_SEND_TIMEOUT:.2f}s"
@@ -1740,31 +1744,40 @@ async def _graceful_shutdown_sequence(
                 timeout_s=FINALIZE_TIMEOUT,
             )
 
-    # 4. CloseStream senden
-    logger.info(f"[{session_id}] Sende CloseStream...")
-    _emit_latency_event(latency_event_callback, "deepgram_close_send")
-    try:
-        await _send_control_with_timeout(
-            connection,
-            "CloseStream",
-            timeout=DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT,
-        )
-        logger.info(f"[{session_id}] CloseStream gesendet")
-    except asyncio.TimeoutError:
-        logger.warning(
-            f"[{session_id}] CloseStream-Send Timeout nach "
-            f"{DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT:.2f}s"
+    # 4. CloseStream nur auf einer weiterhin nutzbaren Verbindung senden.
+    if control_connection_usable:
+        logger.info(f"[{session_id}] Sende CloseStream...")
+        _emit_latency_event(latency_event_callback, "deepgram_close_send")
+        try:
+            await _send_control_with_timeout(
+                connection,
+                "CloseStream",
+                timeout=DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT,
+            )
+            logger.info(f"[{session_id}] CloseStream gesendet")
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"[{session_id}] CloseStream-Send Timeout nach "
+                f"{DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT:.2f}s"
+            )
+            _emit_latency_event(
+                latency_event_callback,
+                "deepgram_close_send_timeout",
+                timeout_s=DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT,
+            )
+        except Exception as exc:
+            logger.warning(f"[{session_id}] CloseStream fehlgeschlagen: {exc}")
+            _emit_latency_event(
+                latency_event_callback,
+                "deepgram_close_send_failed",
+            )
+    else:
+        logger.info(
+            f"[{session_id}] Überspringe CloseStream nach abgebrochenem Finalize-Send"
         )
         _emit_latency_event(
             latency_event_callback,
-            "deepgram_close_send_timeout",
-            timeout_s=DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT,
-        )
-    except Exception as exc:
-        logger.warning(f"[{session_id}] CloseStream fehlgeschlagen: {exc}")
-        _emit_latency_event(
-            latency_event_callback,
-            "deepgram_close_send_failed",
+            "deepgram_close_send_skipped",
         )
 
     # 5. Listener beenden (Guard: nicht den eigenen Task canceln)

--- a/providers/deepgram_stream.py
+++ b/providers/deepgram_stream.py
@@ -34,14 +34,18 @@ from typing import (
     AsyncContextManager,
     AsyncIterator,
     Callable,
+    Literal,
 )
 
 from config import (
     AUDIO_QUEUE_POLL_INTERVAL,
     CLI_BUFFER_LIMIT,
     DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS,
+    DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT,
     DEEPGRAM_CLOSE_TIMEOUT,
+    DEEPGRAM_FINALIZE_SEND_TIMEOUT,
     DEEPGRAM_KEEPALIVE_INTERVAL_SECONDS,
+    DEEPGRAM_KEEPALIVE_SEND_TIMEOUT,
     DEEPGRAM_TAIL_PADDING_SECONDS,
     DEEPGRAM_WS_URL,
     DEFAULT_DEEPGRAM_MODEL,
@@ -645,18 +649,26 @@ class DeepgramWarmConnectionManager:
         )
 
     async def _keepalive(self, prepared: _PreparedDeepgramConnection) -> None:
-        from deepgram.extensions.types.sockets import ListenV1ControlMessage
-
         try:
             while True:
                 await asyncio.sleep(self._keepalive_interval)
-                await prepared.connection.send_control(
-                    ListenV1ControlMessage(type="KeepAlive")
+                await _send_control_with_timeout(
+                    prepared.connection,
+                    "KeepAlive",
+                    timeout=DEEPGRAM_KEEPALIVE_SEND_TIMEOUT,
                 )
         except asyncio.CancelledError:
             raise
         except Exception as exc:
-            logger.debug("Deepgram Warm-WebSocket KeepAlive fehlgeschlagen: %s", exc)
+            if isinstance(exc, TimeoutError):
+                logger.debug(
+                    "Deepgram Warm-WebSocket KeepAlive Timeout nach %.2fs",
+                    DEEPGRAM_KEEPALIVE_SEND_TIMEOUT,
+                )
+            else:
+                logger.debug(
+                    "Deepgram Warm-WebSocket KeepAlive fehlgeschlagen: %s", exc
+                )
             if self._prepared is prepared:
                 self._prepared = None
             prepared.keepalive_task = None
@@ -1275,6 +1287,21 @@ def _emit_latency_event(
         logger.debug("Latency diagnostics callback failed: %s", exc)
 
 
+async def _send_control_with_timeout(
+    connection: AsyncV1SocketClient,
+    control_type: Literal["Finalize", "CloseStream", "KeepAlive"],
+    *,
+    timeout: float,
+) -> None:
+    """Send one Deepgram control frame with a hard coroutine deadline."""
+    from deepgram.extensions.types.sockets import ListenV1ControlMessage
+
+    await asyncio.wait_for(
+        connection.send_control(ListenV1ControlMessage(type=control_type)),
+        timeout=timeout,
+    )
+
+
 def _write_interim_text(path: Path, transcript: str) -> None:
     """Write interim text atomically so readers never see partial payloads."""
     if not hasattr(path, "with_name") or not hasattr(path, "replace"):
@@ -1569,6 +1596,41 @@ async def _graceful_shutdown(
     sample_rate: int = WHISPER_SAMPLE_RATE,
     latency_event_callback: Callable[[str, dict[str, Any] | None], None] | None = None,
 ) -> None:
+    """Run bounded shutdown and always reap sender/listener tasks."""
+    try:
+        await _graceful_shutdown_sequence(
+            connection=connection,
+            state=state,
+            audio_queue=audio_queue,
+            send_task=send_task,
+            listen_task=listen_task,
+            session_id=session_id,
+            sample_rate=sample_rate,
+            latency_event_callback=latency_event_callback,
+        )
+    finally:
+        current_task = asyncio.current_task()
+        cleanup_tasks = [
+            task
+            for task in (send_task, listen_task)
+            if task is not current_task and not task.done()
+        ]
+        for task in cleanup_tasks:
+            task.cancel()
+        if cleanup_tasks:
+            await asyncio.gather(*cleanup_tasks, return_exceptions=True)
+
+
+async def _graceful_shutdown_sequence(
+    connection: AsyncV1SocketClient,
+    state: StreamState,
+    audio_queue: asyncio.Queue[bytes | None],
+    send_task: asyncio.Task[None],
+    listen_task: asyncio.Task[None],
+    session_id: str,
+    sample_rate: int = WHISPER_SAMPLE_RATE,
+    latency_event_callback: Callable[[str, dict[str, Any] | None], None] | None = None,
+) -> None:
     """Sauberes Beenden der Streaming-Session.
 
     Führt die Shutdown-Sequenz in der richtigen Reihenfolge aus:
@@ -1586,8 +1648,6 @@ async def _graceful_shutdown(
         listen_task: Message-Listener Task
         session_id: Session-ID für Logging
     """
-    from deepgram.extensions.types.sockets import ListenV1ControlMessage
-
     # 1. Audio-Sender beenden (einziger Ort für das None-Sentinel)
     # Audio-Callbacks nutzen loop.call_soon_threadsafe(); einmal yielden, damit
     # bereits geplante letzte Chunks vor Tail-Padding und Sentinel in der Queue landen.
@@ -1613,60 +1673,99 @@ async def _graceful_shutdown(
     logger.info(f"[{session_id}] Sende Finalize...")
     _emit_latency_event(latency_event_callback, "deepgram_finalize_send")
     t_finalize_start = time.perf_counter()
+    finalize_sent = False
     try:
-        await connection.send_control(ListenV1ControlMessage(type="Finalize"))
-    except Exception as e:
-        logger.warning(f"[{session_id}] Finalize fehlgeschlagen: {e}")
-
-    # 3. Warten auf finale Transkripte
-    try:
-        await asyncio.wait_for(state.finalize_done.wait(), timeout=FINALIZE_TIMEOUT)
-        t_finalize = (time.perf_counter() - t_finalize_start) * 1000
-        logger.info(f"[{session_id}] Finalize abgeschlossen ({t_finalize:.0f}ms)")
-        _emit_latency_event(
-            latency_event_callback,
-            "deepgram_finalize_done",
-            elapsed_ms=round(t_finalize, 3),
+        await _send_control_with_timeout(
+            connection,
+            "Finalize",
+            timeout=DEEPGRAM_FINALIZE_SEND_TIMEOUT,
         )
-        if (
-            state.finalize_empty_ack_received
-            and not state.finalize_transcript_received
-            and DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS > 0
-        ):
-            # Nicht stur die volle Grace-Zeit warten: Sobald ein spätes
-            # Final-Transkript eintrifft, geht es sofort weiter.
-            try:
-                await asyncio.wait_for(
-                    state.final_transcript_event.wait(),
-                    timeout=DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS,
-                )
-                logger.debug(
-                    f"[{session_id}] Empty-Finalize-Grace: spätes Transkript "
-                    "eingetroffen, Grace vorzeitig beendet"
-                )
-            except asyncio.TimeoutError:
-                pass
+        finalize_sent = True
     except asyncio.TimeoutError:
-        t_finalize = (time.perf_counter() - t_finalize_start) * 1000
         logger.warning(
-            f"[{session_id}] Finalize-Timeout nach {t_finalize:.0f}ms "
-            f"(max: {FINALIZE_TIMEOUT}s)"
+            f"[{session_id}] Finalize-Send Timeout nach "
+            f"{DEEPGRAM_FINALIZE_SEND_TIMEOUT:.2f}s"
         )
         _emit_latency_event(
             latency_event_callback,
-            "deepgram_finalize_timeout",
-            elapsed_ms=round(t_finalize, 3),
-            timeout_s=FINALIZE_TIMEOUT,
+            "deepgram_finalize_send_timeout",
+            timeout_s=DEEPGRAM_FINALIZE_SEND_TIMEOUT,
         )
+    except Exception as exc:
+        logger.warning(f"[{session_id}] Finalize fehlgeschlagen: {exc}")
+        _emit_latency_event(
+            latency_event_callback,
+            "deepgram_finalize_send_failed",
+        )
+
+    # 3. Nur nach erfolgreich gesendetem Finalize auf den Ack warten.
+    if finalize_sent:
+        try:
+            await asyncio.wait_for(state.finalize_done.wait(), timeout=FINALIZE_TIMEOUT)
+            t_finalize = (time.perf_counter() - t_finalize_start) * 1000
+            logger.info(f"[{session_id}] Finalize abgeschlossen ({t_finalize:.0f}ms)")
+            _emit_latency_event(
+                latency_event_callback,
+                "deepgram_finalize_done",
+                elapsed_ms=round(t_finalize, 3),
+            )
+            if (
+                state.finalize_empty_ack_received
+                and not state.finalize_transcript_received
+                and DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS > 0
+            ):
+                # Nicht stur die volle Grace-Zeit warten: Sobald ein spätes
+                # Final-Transkript eintrifft, geht es sofort weiter.
+                try:
+                    await asyncio.wait_for(
+                        state.final_transcript_event.wait(),
+                        timeout=DEEPGRAM_EMPTY_FINALIZE_GRACE_SECONDS,
+                    )
+                    logger.debug(
+                        f"[{session_id}] Empty-Finalize-Grace: spätes Transkript "
+                        "eingetroffen, Grace vorzeitig beendet"
+                    )
+                except asyncio.TimeoutError:
+                    pass
+        except asyncio.TimeoutError:
+            t_finalize = (time.perf_counter() - t_finalize_start) * 1000
+            logger.warning(
+                f"[{session_id}] Finalize-Timeout nach {t_finalize:.0f}ms "
+                f"(max: {FINALIZE_TIMEOUT}s)"
+            )
+            _emit_latency_event(
+                latency_event_callback,
+                "deepgram_finalize_timeout",
+                elapsed_ms=round(t_finalize, 3),
+                timeout_s=FINALIZE_TIMEOUT,
+            )
 
     # 4. CloseStream senden
     logger.info(f"[{session_id}] Sende CloseStream...")
     _emit_latency_event(latency_event_callback, "deepgram_close_send")
     try:
-        await connection.send_control(ListenV1ControlMessage(type="CloseStream"))
+        await _send_control_with_timeout(
+            connection,
+            "CloseStream",
+            timeout=DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT,
+        )
         logger.info(f"[{session_id}] CloseStream gesendet")
-    except Exception as e:
-        logger.warning(f"[{session_id}] CloseStream fehlgeschlagen: {e}")
+    except asyncio.TimeoutError:
+        logger.warning(
+            f"[{session_id}] CloseStream-Send Timeout nach "
+            f"{DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT:.2f}s"
+        )
+        _emit_latency_event(
+            latency_event_callback,
+            "deepgram_close_send_timeout",
+            timeout_s=DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT,
+        )
+    except Exception as exc:
+        logger.warning(f"[{session_id}] CloseStream fehlgeschlagen: {exc}")
+        _emit_latency_event(
+            latency_event_callback,
+            "deepgram_close_send_failed",
+        )
 
     # 5. Listener beenden (Guard: nicht den eigenen Task canceln)
     logger.info(f"[{session_id}] Beende Listener...")
@@ -2021,6 +2120,11 @@ async def deepgram_stream_core(
         play_ready=play_ready,
         stream_start=stream_start,
         audio_level_callback=audio_level_callback,
+    )
+    _emit_latency_event(
+        latency_event_callback,
+        "audio_stream_started",
+        elapsed_ms=round((time.perf_counter() - stream_start) * 1000, 3),
     )
 
     create_connection = connection_factory or _create_deepgram_connection

--- a/pulsescribe_daemon.py
+++ b/pulsescribe_daemon.py
@@ -54,7 +54,11 @@ emergency_log("=== Booting PulseScribe Daemon ===")
 
 try:
     from config import INTERIM_FILE, VAD_THRESHOLD, WHISPER_SAMPLE_RATE
-    from config import TRANSCRIBING_TIMEOUT, PRELOAD_WARMUP_DURATION, LOCAL_KEEPALIVE_INTERVAL
+    from config import (
+        TRANSCRIBING_TIMEOUT,
+        PRELOAD_WARMUP_DURATION,
+        LOCAL_KEEPALIVE_INTERVAL,
+    )
     from utils import setup_logging, show_error_alert
     from config import DEFAULT_DEEPGRAM_MODEL, DEFAULT_LOCAL_MODEL
     from utils.env import (
@@ -77,9 +81,16 @@ try:
         is_permission_related_message,
     )
     from utils.log_tail import read_file_tail_text
+    from utils.macos_latency_diagnostics import (
+        MacOSLatencyRun,
+        start_macos_latency_run,
+    )
     from utils.timing import redacted_text_summary
     from ui import MenuBarController, OverlayController
-    from ui.daemon_status_feedback import build_daemon_status_label, infer_daemon_status_error
+    from ui.daemon_status_feedback import (
+        build_daemon_status_label,
+        infer_daemon_status_error,
+    )
     from ui.menubar import build_menubar_title
 except Exception as e:
     emergency_log(f"CRITICAL IMPORT ERROR: {e}")
@@ -165,6 +176,15 @@ class EffectiveDaemonOptions:
     toggle_hotkey: str | None
     hold_hotkey: str | None
 
+
+@dataclass(frozen=True)
+class LocalKeepaliveRequest:
+    provider: object
+    generation: int
+    signature: tuple[str | None, ...]
+    model: str | None
+
+
 # =============================================================================
 # PulseScribeDaemon: Hauptklasse
 # =============================================================================
@@ -224,7 +244,9 @@ class PulseScribeDaemon:
         self._last_rtf: float | None = (
             None  # Real-Time Factor der letzten Transkription
         )
-        self._last_was_refined: bool = False  # Ob Refinement den Text tatsächlich verändert hat
+        self._last_was_refined: bool = (
+            False  # Ob Refinement den Text tatsächlich verändert hat
+        )
 
         # Stop-Event für _deepgram_stream_core
         self._stop_event: threading.Event | None = None
@@ -285,9 +307,23 @@ class PulseScribeDaemon:
         self._pending_hotkey_reconfigure = False
         # Preload-Status für lokales Modell (für Performance-Debugging)
         self._local_preload_complete = threading.Event()
-        # Keep-Alive Timer für Metal-Shader (verhindert Cache-Eviction bei Inaktivität)
-        self._keepalive_stop_event = threading.Event()
+        # Generation-bound local preload/keepalive lifecycle.
+        self._local_warm_lock = threading.Lock()
+        self._local_cache_reconcile_lock = threading.Lock()
+        self._local_warm_generation = 0
+        self._local_preload_signature: tuple[str | None, ...] | None = None
+        self._local_preload_thread: threading.Thread | None = None
+        self._keepalive_stop_event: threading.Event | None = None
         self._keepalive_thread: threading.Thread | None = None
+        self._keepalive_request: LocalKeepaliveRequest | None = None
+        self._pending_keepalive_request: LocalKeepaliveRequest | None = None
+        # Per-run terminal delivery bypasses timer polling for results/errors.
+        self._terminal_claimed_run_id: int | None = None
+        self._latency_run: MacOSLatencyRun | None = None
+        # Import-only audio prewarm; never opens or probes the microphone.
+        self._audio_prewarm_lock = threading.Lock()
+        self._audio_prewarm_started = False
+        self._audio_prewarm_complete = threading.Event()
 
     # =============================================================================
     # Thread-safe State Properties
@@ -346,6 +382,115 @@ class PulseScribeDaemon:
             fn(*args, **kwargs)
         except Exception:
             pass
+
+    def _prewarm_audio_dependencies_async(self) -> bool:
+        """Import the lazy recording stack without touching microphone hardware."""
+        with self._audio_prewarm_lock:
+            if self._audio_prewarm_started:
+                return False
+            self._audio_prewarm_started = True
+            self._audio_prewarm_complete.clear()
+
+        def _prewarm() -> None:
+            import importlib
+
+            try:
+                for module_name in ("numpy", "sounddevice", "soundfile"):
+                    importlib.import_module(module_name)
+                logger.debug("Audio-Abhängigkeiten vorab geladen")
+            except Exception as exc:
+                logger.debug("Audio-Prewarm fehlgeschlagen: %s", exc)
+            finally:
+                self._audio_prewarm_complete.set()
+
+        try:
+            threading.Thread(
+                target=_prewarm,
+                daemon=True,
+                name="AudioDependencyPrewarm",
+            ).start()
+        except Exception:
+            with self._audio_prewarm_lock:
+                self._audio_prewarm_started = False
+            self._audio_prewarm_complete.set()
+            return False
+        return True
+
+    def _publish_worker_terminal(
+        self,
+        *,
+        run_id: int,
+        result_queue_ref: queue.Queue[DaemonMessage | Exception],
+        terminal: DaemonMessage | Exception,
+        latency_run: MacOSLatencyRun,
+    ) -> None:
+        """Deliver a terminal worker outcome promptly on the AppKit main thread."""
+        event_name = (
+            "error_published" if isinstance(terminal, Exception) else "result_published"
+        )
+        latency_run.mark(event_name)
+
+        # Worker methods are called synchronously by a few tests and CLI helpers.
+        # Keep the legacy polling fallback in that unsupported production shape.
+        if threading.current_thread() is threading.main_thread():
+            result_queue_ref.put(terminal)
+            return
+
+        def _deliver() -> None:
+            self._claim_and_handle_worker_terminal(
+                run_id=run_id,
+                result_queue_ref=result_queue_ref,
+                terminal=terminal,
+                latency_run=latency_run,
+            )
+
+        try:
+            from Foundation import NSOperationQueue  # type: ignore[import-not-found]
+
+            NSOperationQueue.mainQueue().addOperationWithBlock_(_deliver)
+        except Exception as exc:
+            logger.debug(
+                "Terminal-Main-Dispatch fehlgeschlagen, nutze Polling: %s", exc
+            )
+            result_queue_ref.put(terminal)
+
+    def _claim_and_handle_worker_terminal(
+        self,
+        *,
+        run_id: int,
+        result_queue_ref: queue.Queue[DaemonMessage | Exception],
+        terminal: DaemonMessage | Exception,
+        latency_run: MacOSLatencyRun,
+    ) -> bool:
+        """Handle the first terminal outcome for the current, non-abandoned run."""
+        with self._state_lock:
+            is_current = (
+                run_id == self._active_run_id
+                and result_queue_ref is self._result_queue
+                and not self._worker_abandoned
+            )
+            if not is_current or self._terminal_claimed_run_id == run_id:
+                claimed = False
+            else:
+                self._terminal_claimed_run_id = run_id
+                if self._latency_run is latency_run:
+                    self._latency_run = None
+                claimed = True
+
+        if not claimed:
+            latency_run.finish("stale")
+            return False
+
+        latency_run.mark("result_received_main")
+        self._stop_result_polling()
+        if isinstance(terminal, Exception):
+            self._handle_worker_error(terminal, latency_run=latency_run)
+        else:
+            self._handle_transcript_result(
+                str(terminal.payload or ""),
+                latency_run=latency_run,
+            )
+        return True
 
     def _set_worker_phase(
         self, phase: str, *, run_id: int | None = None, force: bool = False
@@ -687,128 +832,300 @@ class PulseScribeDaemon:
         end = min(mono.shape[0], last * hop + window + int(pad_s * sample_rate))
         return mono[start:end].astype(np.float32, copy=False)
 
-    def _preload_local_model_async(self) -> None:
-        """Lädt lokales Modell im Hintergrund vor (reduziert erste Latenz)."""
+    def _is_local_warm_generation_current(
+        self,
+        generation: int,
+        signature: tuple[str | None, ...],
+    ) -> bool:
+        with self._local_warm_lock:
+            return (
+                self.mode == "local"
+                and generation == self._local_warm_generation
+                and signature == self._local_preload_signature
+            )
+
+    def _cancel_local_warm_lifecycle(self, *, wait: bool = False) -> None:
+        """Invalidate stale preload completions and stop the current keepalive."""
+        with self._local_warm_lock:
+            self._local_warm_generation += 1
+            self._local_preload_signature = None
+            self._local_preload_complete.clear()
+            self._pending_keepalive_request = None
+        self._stop_keepalive_timer(wait=wait)
+
+    def _preload_local_model_async(self) -> bool:
+        """Preload one local model generation without spawning duplicate workers."""
         if self.mode != "local":
-            return
+            self._cancel_local_warm_lifecycle()
+            return False
+
         provider = self._get_provider("local")
         if not hasattr(provider, "preload"):
-            return
+            return False
 
-        # Event zurücksetzen falls ein vorheriger Preload lief (z.B. nach Settings-Reload)
-        self._local_preload_complete.clear()
+        signature = self._local_provider_memory_signature()
+        model_snapshot = self.model
+        language_snapshot = self.language or "en"
 
-        def _preload():
-            t0 = time.perf_counter()
-            model_name = self.model or "turbo"
-            # Phase 1: Loading
-            self._update_state(AppState.LOADING, f"Loading {model_name}...")
-            try:
-                provider.preload(self.model)  # type: ignore[attr-defined]
-                t_preload = time.perf_counter() - t0
-                # Runtime-Info für Logging (Device, Compute-Type)
-                runtime_info = ""
-                if hasattr(provider, "get_runtime_info"):
-                    info = provider.get_runtime_info()
-                    device_str = (info.get("device") or "unknown").upper()
-                    compute = info.get("compute_type")
-                    runtime_info = f", Device: {device_str}"
-                    if compute:
-                        runtime_info += f", Compute: {compute}"
-                logger.info(f"Lokales Modell vorab geladen ({t_preload:.2f}s{runtime_info})")
-                warmup_flag = get_env_bool("PULSESCRIBE_LOCAL_WARMUP")
-                backend = getattr(provider, "backend", None) or getattr(
-                    provider, "_backend", None
-                )
-                # Daemon-Warmup nur fuer whisper/faster (MLX/Lightning haben eigenes Warmup)
-                should_warmup = (
-                    warmup_flag
-                    if warmup_flag is not None
-                    else backend in ("whisper", "faster")
-                )
-                if should_warmup and hasattr(provider, "transcribe_audio"):
-                    import numpy as np
+        with self._local_warm_lock:
+            if (
+                self._local_preload_signature == signature
+                and self._local_preload_thread is not None
+            ):
+                return False
+            if (
+                self._local_preload_signature == signature
+                and self._local_preload_complete.is_set()
+            ):
+                return False
 
-                    self._update_state(AppState.LOADING, "Warming up...")
-                    warmup_samples = int(WHISPER_SAMPLE_RATE * PRELOAD_WARMUP_DURATION)
-                    warmup_audio = np.zeros(warmup_samples, dtype=np.float32)
-                    try:
-                        provider.transcribe_audio(  # type: ignore[attr-defined]
-                            warmup_audio,
-                            model=self.model,
-                            language=self.language or "en",
+            self._local_warm_generation += 1
+            generation = self._local_warm_generation
+            self._local_preload_signature = signature
+            self._local_preload_complete.clear()
+
+            def _preload() -> None:
+                t0 = time.perf_counter()
+                model_name = model_snapshot or "turbo"
+                try:
+                    if self._is_local_warm_generation_current(generation, signature):
+                        if self._current_state in (AppState.IDLE, AppState.LOADING):
+                            self._update_state(
+                                AppState.LOADING,
+                                f"Loading {model_name}...",
+                            )
+                    provider.preload(model_snapshot)  # type: ignore[attr-defined]
+                    t_preload = time.perf_counter() - t0
+                    if not self._is_local_warm_generation_current(
+                        generation, signature
+                    ):
+                        return
+
+                    runtime_info = ""
+                    if hasattr(provider, "get_runtime_info"):
+                        info = provider.get_runtime_info()
+                        device_str = (info.get("device") or "unknown").upper()
+                        compute = info.get("compute_type")
+                        runtime_info = f", Device: {device_str}"
+                        if compute:
+                            runtime_info += f", Compute: {compute}"
+                    logger.info(
+                        f"Lokales Modell vorab geladen ({t_preload:.2f}s{runtime_info})"
+                    )
+
+                    warmup_flag = get_env_bool("PULSESCRIBE_LOCAL_WARMUP")
+                    backend = getattr(provider, "backend", None) or getattr(
+                        provider, "_backend", None
+                    )
+                    should_warmup = (
+                        warmup_flag
+                        if warmup_flag is not None
+                        else backend in ("whisper", "faster")
+                    )
+                    if should_warmup and hasattr(provider, "transcribe_audio"):
+                        import numpy as np
+
+                        if self._current_state == AppState.LOADING:
+                            self._update_state(AppState.LOADING, "Warming up...")
+                        warmup_samples = int(
+                            WHISPER_SAMPLE_RATE * PRELOAD_WARMUP_DURATION
                         )
-                        logger.debug("Lokales Modell warmup abgeschlossen")
-                    except Exception as e:
-                        logger.debug(f"Lokales Modell warmup fehlgeschlagen: {e}")
-                self._local_preload_complete.set()
-                # Zurück zu IDLE nach erfolgreichem Preload
-                self._update_state(AppState.IDLE)
-                # Auditive Rückmeldung: User kann jetzt mit minimaler Latenz aufnehmen
-                get_sound_player().play("warmup")
-                # Keep-Alive Timer starten (hält Metal-Shader warm)
-                self._start_keepalive_timer()
-            except Exception as e:
-                logger.warning(f"Preload lokales Modell fehlgeschlagen: {e}")
-                self._local_preload_complete.set()  # Setze trotzdem um Deadlock zu vermeiden
-                # Zurück zu IDLE auch bei Fehler (Fallback auf On-Demand-Loading)
-                self._update_state(AppState.IDLE)
+                        warmup_audio = np.zeros(warmup_samples, dtype=np.float32)
+                        try:
+                            provider.transcribe_audio(  # type: ignore[attr-defined]
+                                warmup_audio,
+                                model=model_snapshot,
+                                language=language_snapshot,
+                            )
+                            logger.debug("Lokales Modell warmup abgeschlossen")
+                        except Exception as exc:
+                            logger.debug(
+                                "Lokales Modell warmup fehlgeschlagen: %s", exc
+                            )
 
-        threading.Thread(target=_preload, daemon=True, name="LocalPreload").start()
+                    if not self._is_local_warm_generation_current(
+                        generation, signature
+                    ):
+                        return
+                    self._local_preload_complete.set()
+                    notify_ready = self._current_state == AppState.LOADING
+                    if notify_ready:
+                        self._update_state(AppState.IDLE)
+                        get_sound_player().play("warmup")
+                    self._start_keepalive_timer(
+                        provider=provider,
+                        generation=generation,
+                        signature=signature,
+                        model=model_snapshot,
+                    )
+                except Exception as exc:
+                    if self._is_local_warm_generation_current(generation, signature):
+                        logger.warning("Preload lokales Modell fehlgeschlagen: %s", exc)
+                        with self._local_warm_lock:
+                            if generation == self._local_warm_generation:
+                                self._local_preload_signature = None
+                        self._local_preload_complete.set()
+                        if self._current_state == AppState.LOADING:
+                            self._update_state(AppState.IDLE)
+                finally:
+                    current = threading.current_thread()
+                    with self._local_warm_lock:
+                        if self._local_preload_thread is current:
+                            self._local_preload_thread = None
 
-    def _start_keepalive_timer(self) -> None:
-        """Startet Keep-Alive Timer für Metal-Shader (nur für lokale Metal-Backends).
+            preload_thread = threading.Thread(
+                target=_preload,
+                daemon=True,
+                name="LocalPreload",
+            )
+            self._local_preload_thread = preload_thread
 
-        Der Timer ruft periodisch provider.keepalive() auf, um Metal-Shader
-        im GPU-Cache zu halten und Cache-Eviction bei Inaktivität zu verhindern.
-        """
-        if self.mode != "local":
-            return
+        self._stop_keepalive_timer()
+        try:
+            preload_thread.start()
+        except Exception:
+            with self._local_warm_lock:
+                if self._local_preload_thread is preload_thread:
+                    self._local_preload_thread = None
+                    self._local_preload_signature = None
+            self._local_preload_complete.set()
+            return False
+        return True
 
+    def _start_keepalive_timer(
+        self,
+        *,
+        provider: object,
+        generation: int,
+        signature: tuple[str | None, ...],
+        model: str | None,
+    ) -> bool:
+        """Start exactly one keepalive worker for the current local generation."""
+        if not self._is_local_warm_generation_current(generation, signature):
+            return False
         if LOCAL_KEEPALIVE_INTERVAL <= 0:
             logger.debug("Keep-Alive Timer deaktiviert (Interval <= 0)")
-            return
-
-        provider = self._get_provider("local")
+            return False
         if not hasattr(provider, "keepalive"):
-            return
+            return False
 
-        # Backend prüfen - nur MLX/Lightning brauchen Keep-Alive
         if hasattr(provider, "_ensure_runtime_config"):
             provider._ensure_runtime_config()  # type: ignore[attr-defined]
         backend = getattr(provider, "_backend", None)
         if backend not in ("mlx", "lightning"):
-            logger.debug(f"Keep-Alive nicht nötig für Backend '{backend}'")
-            return
+            logger.debug("Keep-Alive nicht nötig für Backend '%s'", backend)
+            return False
 
-        self._keepalive_stop_event.clear()
-
-        def _keepalive_loop():
-            logger.info(
-                f"Keep-Alive Timer gestartet (Interval: {LOCAL_KEEPALIVE_INTERVAL}s, Backend: {backend})"
-            )
-            while not self._keepalive_stop_event.wait(LOCAL_KEEPALIVE_INTERVAL):
-                # Nur Keep-Alive wenn IDLE (nicht während Recording/Transcribing)
-                if self._current_state != AppState.IDLE:
-                    logger.debug("Keep-Alive übersprungen (nicht IDLE)")
-                    continue
-                try:
-                    provider.keepalive(self.model)  # type: ignore[attr-defined]
-                except Exception as e:
-                    logger.debug(f"Keep-Alive fehlgeschlagen: {e}")
-            logger.debug("Keep-Alive Timer gestoppt")
-
-        self._keepalive_thread = threading.Thread(
-            target=_keepalive_loop, daemon=True, name="LocalKeepalive"
+        request = LocalKeepaliveRequest(
+            provider=provider,
+            generation=generation,
+            signature=signature,
+            model=model,
         )
-        self._keepalive_thread.start()
+        stop_event = threading.Event()
 
-    def _stop_keepalive_timer(self) -> None:
-        """Stoppt den Keep-Alive Timer."""
-        self._keepalive_stop_event.set()
-        if self._keepalive_thread is not None:
-            self._keepalive_thread.join(timeout=1.0)
-            self._keepalive_thread = None
+        def _keepalive_loop() -> None:
+            logger.info(
+                "Keep-Alive Timer gestartet (Interval: %ss, Backend: %s)",
+                LOCAL_KEEPALIVE_INTERVAL,
+                backend,
+            )
+            try:
+                while not stop_event.wait(LOCAL_KEEPALIVE_INTERVAL):
+                    if not self._is_local_warm_generation_current(
+                        generation, signature
+                    ):
+                        break
+                    if self._current_state != AppState.IDLE:
+                        logger.debug("Keep-Alive übersprungen (nicht IDLE)")
+                        continue
+                    try:
+                        provider.keepalive(model)  # type: ignore[attr-defined]
+                    except Exception as exc:
+                        logger.debug("Keep-Alive fehlgeschlagen: %s", exc)
+            finally:
+                current = threading.current_thread()
+                pending_request = None
+                with self._local_warm_lock:
+                    if self._keepalive_thread is current:
+                        self._keepalive_thread = None
+                        self._keepalive_stop_event = None
+                        self._keepalive_request = None
+                        pending_request = self._pending_keepalive_request
+                        self._pending_keepalive_request = None
+                logger.debug("Keep-Alive Timer gestoppt")
+                if pending_request is not None:
+                    self._start_keepalive_timer(
+                        provider=pending_request.provider,
+                        generation=pending_request.generation,
+                        signature=pending_request.signature,
+                        model=pending_request.model,
+                    )
+
+        thread = threading.Thread(
+            target=_keepalive_loop,
+            daemon=True,
+            name="LocalKeepalive",
+        )
+        with self._local_warm_lock:
+            if not (
+                self.mode == "local"
+                and generation == self._local_warm_generation
+                and signature == self._local_preload_signature
+            ):
+                return False
+            existing = self._keepalive_thread
+            if existing is not None and existing.is_alive():
+                active_request = self._keepalive_request
+                same_request = (
+                    active_request is not None
+                    and active_request.provider is request.provider
+                    and active_request.generation == request.generation
+                    and active_request.signature == request.signature
+                    and active_request.model == request.model
+                )
+                if not same_request:
+                    self._pending_keepalive_request = request
+                    logger.debug(
+                        "Keep-Alive läuft noch; Ersatz für aktuelle Generation vorgemerkt"
+                    )
+                return False
+            self._pending_keepalive_request = None
+            self._keepalive_stop_event = stop_event
+            self._keepalive_thread = thread
+            self._keepalive_request = request
+        try:
+            thread.start()
+        except Exception:
+            with self._local_warm_lock:
+                if self._keepalive_thread is thread:
+                    self._keepalive_thread = None
+                    self._keepalive_stop_event = None
+                    self._keepalive_request = None
+            return False
+        return True
+
+    def _stop_keepalive_timer(self, *, wait: bool = False) -> bool:
+        """Signal the tracked keepalive; optionally wait during app cleanup."""
+        with self._local_warm_lock:
+            stop_event = self._keepalive_stop_event
+            thread = self._keepalive_thread
+        if stop_event is not None:
+            stop_event.set()
+        if thread is None:
+            return True
+        if wait and thread is not threading.current_thread() and thread.is_alive():
+            thread.join(timeout=1.0)
+        stopped = not thread.is_alive()
+        if stopped:
+            with self._local_warm_lock:
+                if self._keepalive_thread is thread:
+                    self._keepalive_thread = None
+                    self._keepalive_stop_event = None
+                    self._keepalive_request = None
+        else:
+            logger.debug("Keep-Alive Worker beendet sich noch im Hintergrund")
+        return stopped
 
     def _update_state(self, state: AppState, text: str | None = None) -> None:
         """Aktualisiert State und benachrichtigt UI-Controller.
@@ -838,7 +1155,12 @@ class PulseScribeDaemon:
         if state == AppState.TRANSCRIBING:
             # Starte Watchdog wenn TRANSCRIBING beginnt
             self._start_transcribing_watchdog()
-        elif state in (AppState.DONE, AppState.NO_SPEECH, AppState.ERROR, AppState.IDLE):
+        elif state in (
+            AppState.DONE,
+            AppState.NO_SPEECH,
+            AppState.ERROR,
+            AppState.IDLE,
+        ):
             # Stoppe Watchdog bei Abschluss
             self._stop_transcribing_watchdog()
 
@@ -1022,8 +1344,16 @@ class PulseScribeDaemon:
         if cb:
             self._safe_call(cb, transcript, error)
 
-    def _handle_worker_error(self, err: Exception) -> None:
+    def _handle_worker_error(
+        self,
+        err: Exception,
+        *,
+        latency_run: MacOSLatencyRun | None = None,
+    ) -> None:
         self._last_rtf = None  # RTF bei Fehler zurücksetzen
+        run = latency_run or self._latency_run
+        if run is not None:
+            run.finish("error", error_type=type(err).__name__)
         error_info = infer_daemon_status_error(err)
         error_text = build_daemon_status_label(
             AppState.ERROR,
@@ -1080,10 +1410,8 @@ class PulseScribeDaemon:
                 daemon._update_state(AppState.IDLE)
                 daemon._apply_pending_hotkey_reconfigure_if_safe()
 
-        self._error_reset_timer = (
-            NSTimer.scheduledTimerWithTimeInterval_repeats_block_(
-                0.8, False, reset_to_idle
-            )
+        self._error_reset_timer = NSTimer.scheduledTimerWithTimeInterval_repeats_block_(
+            0.8, False, reset_to_idle
         )
 
     def _stop_error_reset_timer(self) -> None:
@@ -1092,8 +1420,15 @@ class PulseScribeDaemon:
             self._error_reset_timer.invalidate()
             self._error_reset_timer = None
 
-    def _enter_no_speech_state(self, *, delay_seconds: float = 1.2) -> None:
+    def _enter_no_speech_state(
+        self,
+        *,
+        delay_seconds: float = 1.2,
+        latency_run: MacOSLatencyRun | None = None,
+    ) -> None:
         """Show a brief neutral no-speech result before returning to ready."""
+        if latency_run is not None:
+            latency_run.finish("no_speech")
         self._last_rtf = None
         self._recording = False
         self._hold_state.reset()
@@ -1108,8 +1443,17 @@ class PulseScribeDaemon:
         timer.daemon = True
         timer.start()
 
-    def _handle_transcript_result(self, transcript: str) -> None:
+    def _handle_transcript_result(
+        self,
+        transcript: str,
+        *,
+        latency_run: MacOSLatencyRun | None = None,
+    ) -> None:
         """Verarbeitet das fertige Transkript: UI-Update, History, Auto-Paste."""
+        run = latency_run or self._latency_run
+        if run is not None:
+            run.mark_once("result_received_main")
+
         # Test-Modus: Callback ausführen, kein Auto-Paste
         if self._test_run_active:
             self._last_rtf = None  # RTF im Test-Modus nicht relevant
@@ -1117,13 +1461,15 @@ class PulseScribeDaemon:
             self._update_state(
                 AppState.DONE if transcript else AppState.IDLE, transcript
             )
+            if run is not None:
+                run.finish("test_success" if transcript else "test_no_speech")
             self._apply_pending_hotkey_reconfigure_if_safe()
             return
 
         # Leeres Transkript: kurzes, neutrales Feedback statt stillem Reset
         if not transcript:
             logger.warning("Leeres Transkript")
-            self._enter_no_speech_state()
+            self._enter_no_speech_state(latency_run=run)
             return
 
         # Erfolgreiche Transkription: State → Sound → UI-Flush → History → Paste
@@ -1132,9 +1478,11 @@ class PulseScribeDaemon:
         self._update_state(AppState.DONE, overlay_text)
         get_sound_player().play("done")  # Sofortiges auditives Feedback
         self._flush_ui_and_wait()  # ✅ muss sichtbar sein BEVOR Text eingefügt wird
-        self._save_to_history(transcript)
-        self._paste_result(transcript)
+        self._save_to_history(transcript, latency_run=run)
+        self._paste_result(transcript, latency_run=run)
         self._update_state(AppState.IDLE)  # Reset nach erfolgreichem Paste
+        if run is not None:
+            run.finish("success")
         self._apply_pending_hotkey_reconfigure_if_safe()
 
     def _maybe_refine(
@@ -1144,6 +1492,7 @@ class PulseScribeDaemon:
         phase_prefix: str,
         run_id: int,
         result_queue: queue.Queue[DaemonMessage | Exception],
+        latency_run: MacOSLatencyRun | None = None,
     ) -> str:
         """Wendet optionales LLM-Refinement auf das Transkript an.
 
@@ -1156,27 +1505,38 @@ class PulseScribeDaemon:
 
         self._set_worker_phase(f"{phase_prefix}:refining", run_id=run_id)
         result_queue.put(
-            DaemonMessage(
-                type=MessageType.STATUS_UPDATE, payload=AppState.REFINING
-            )
+            DaemonMessage(type=MessageType.STATUS_UPDATE, payload=AppState.REFINING)
         )
         from refine.llm import maybe_refine_transcript
 
+        if latency_run is not None:
+            latency_run.mark("refine_start")
         original = transcript
-        transcript = maybe_refine_transcript(
-            transcript,
-            refine=True,
-            refine_model=self.refine_model,
-            refine_provider=self.refine_provider,
-            context=self.context,
-        )
+        try:
+            transcript = maybe_refine_transcript(
+                transcript,
+                refine=True,
+                refine_model=self.refine_model,
+                refine_provider=self.refine_provider,
+                context=self.context,
+            )
+        finally:
+            if latency_run is not None:
+                latency_run.mark("refine_done")
         self._last_was_refined = transcript != original
         return transcript
 
-    def _save_to_history(self, transcript: str) -> None:
+    def _save_to_history(
+        self,
+        transcript: str,
+        *,
+        latency_run: MacOSLatencyRun | None = None,
+    ) -> None:
         """Speichert Transkript in der Historie."""
         from utils.history import save_transcript
 
+        if latency_run is not None:
+            latency_run.mark("history_start")
         try:
             save_transcript(
                 transcript,
@@ -1186,6 +1546,9 @@ class PulseScribeDaemon:
             )
         except Exception as e:
             logger.warning(f"History save failed: {e}")
+        finally:
+            if latency_run is not None:
+                latency_run.mark("history_done")
 
     def _format_done_text(self, transcript: str) -> str:
         """Formatiert den Overlay-Text für DONE-State mit optionalem RTF."""
@@ -1727,10 +2090,27 @@ class PulseScribeDaemon:
                 f"(phase={self._worker_phase})"
             )
 
+        # Modus-Entscheidung: Streaming vs. Recording
+        use_streaming = effective_mode == "deepgram" and get_env_bool_default(
+            "PULSESCRIBE_STREAMING", True
+        )
+
         self._run_counter += 1
         run_id = self._run_counter
+        previous_latency_run = self._latency_run
+        if previous_latency_run is not None:
+            previous_latency_run.finish("superseded")
+        latency_run = start_macos_latency_run(
+            mode=effective_mode,
+            streaming=use_streaming,
+            logger=logger,
+        )
+        latency_run.mark("hotkey_accepted")
+
         self._active_run_id = run_id
         self._worker_abandoned = False
+        self._terminal_claimed_run_id = None
+        self._latency_run = latency_run
         self._set_worker_phase(f"starting:{effective_mode}", run_id=run_id)
 
         self._recording = True
@@ -1745,11 +2125,6 @@ class PulseScribeDaemon:
         self._result_queue = run_result_queue
         run_stop_event = threading.Event()
         self._stop_event = run_stop_event
-
-        # Modus-Entscheidung: Streaming vs. Recording
-        use_streaming = effective_mode == "deepgram" and get_env_bool_default(
-            "PULSESCRIBE_STREAMING", True
-        )
         self._run_mode = effective_mode
 
         if use_streaming:
@@ -1764,7 +2139,7 @@ class PulseScribeDaemon:
         # Worker-Thread starten
         self._worker_thread = threading.Thread(
             target=target,
-            args=(run_id, run_result_queue, run_stop_event),
+            args=(run_id, run_result_queue, run_stop_event, latency_run),
             daemon=True,
             name=name,
         )
@@ -1945,6 +2320,7 @@ class PulseScribeDaemon:
         run_id: int | None = None,
         result_queue_ref: queue.Queue[DaemonMessage | Exception] | None = None,
         stop_event: threading.Event | None = None,
+        latency_run: MacOSLatencyRun | None = None,
     ) -> None:
         """
         Hintergrund-Thread für Deepgram-Streaming.
@@ -1961,6 +2337,9 @@ class PulseScribeDaemon:
         run_id = self._active_run_id if run_id is None else run_id
         result_queue_ref = result_queue_ref or self._result_queue
         stop_event = stop_event or self._stop_event
+        latency_run = (
+            latency_run or self._latency_run or start_macos_latency_run(enabled=False)
+        )
 
         self._set_worker_phase("streaming:boot", run_id=run_id)
         logger.debug(f"StreamingWorker gestartet (run={run_id})")
@@ -1978,19 +2357,27 @@ class PulseScribeDaemon:
             try:
                 logger.debug(f"Starte deepgram_stream_core (model={model})")
                 self._set_worker_phase("streaming:capture", run_id=run_id)
+
+                def _on_stream_audio_level(level: float) -> None:
+                    latency_run.mark_once("first_audio_callback")
+                    self._on_audio_level(
+                        level,
+                        run_id=run_id,
+                        result_queue_ref=result_queue_ref,
+                    )
+
+                latency_run.mark("streaming_core_start")
                 transcript = loop.run_until_complete(
                     deepgram_stream_core(
                         model=model,
                         language=self.language,
                         play_ready=True,
                         external_stop_event=stop_event,
-                        audio_level_callback=lambda level: self._on_audio_level(
-                            level,
-                            run_id=run_id,
-                            result_queue_ref=result_queue_ref,
-                        ),
+                        audio_level_callback=_on_stream_audio_level,
+                        latency_event_callback=latency_run.event,
                     )
                 )
+                latency_run.mark("streaming_core_done")
                 logger.debug(
                     f"deepgram_stream_core abgeschlossen: {len(transcript)} Zeichen"
                 )
@@ -2001,14 +2388,18 @@ class PulseScribeDaemon:
                     phase_prefix="streaming",
                     run_id=run_id,
                     result_queue=result_queue_ref,
+                    latency_run=latency_run,
                 )
 
                 logger.debug("Sende TRANSCRIPT_RESULT")
                 self._set_worker_phase("streaming:publishing-result", run_id=run_id)
-                result_queue_ref.put(
-                    DaemonMessage(
+                self._publish_worker_terminal(
+                    run_id=run_id,
+                    result_queue_ref=result_queue_ref,
+                    terminal=DaemonMessage(
                         type=MessageType.TRANSCRIPT_RESULT, payload=transcript
-                    )
+                    ),
+                    latency_run=latency_run,
                 )
                 self._set_worker_phase("streaming:finished", run_id=run_id)
 
@@ -2019,14 +2410,25 @@ class PulseScribeDaemon:
         except Exception as e:
             logger.exception(f"Streaming-Worker Fehler: {e}")
             emergency_log(f"StreamingWorker Exception: {type(e).__name__}: {e}")
-            result_queue_ref.put(e)
+            self._publish_worker_terminal(
+                run_id=run_id,
+                result_queue_ref=result_queue_ref,
+                terminal=e,
+                latency_run=latency_run,
+            )
 
-    @staticmethod
     def _put_empty_transcript_result(
+        self,
+        *,
+        run_id: int,
         result_queue_ref: queue.Queue[DaemonMessage | Exception],
+        latency_run: MacOSLatencyRun,
     ) -> None:
-        result_queue_ref.put(
-            DaemonMessage(type=MessageType.TRANSCRIPT_RESULT, payload="")
+        self._publish_worker_terminal(
+            run_id=run_id,
+            result_queue_ref=result_queue_ref,
+            terminal=DaemonMessage(type=MessageType.TRANSCRIPT_RESULT, payload=""),
+            latency_run=latency_run,
         )
 
     def _capture_recording_audio(
@@ -2035,6 +2437,7 @@ class PulseScribeDaemon:
         run_id: int | None,
         result_queue_ref: queue.Queue[DaemonMessage | Exception],
         stop_event: threading.Event | None,
+        latency_run: MacOSLatencyRun,
     ) -> tuple[list[Any], float, bool]:
         import numpy as np
         import sounddevice as sd
@@ -2046,11 +2449,9 @@ class PulseScribeDaemon:
         finished_event = threading.Event()
         callback_abort_exc = getattr(sd, "CallbackAbort", None)
 
-        self._set_worker_phase("recording:ready-sound", run_id=run_id)
-        player.play("ready")
-
         def callback(indata, _frames, _time, _status):
             nonlocal max_rms, had_speech
+            latency_run.mark_once("first_audio_callback")
             recorded_chunks.append(indata.copy())
             rms = float(np.sqrt(np.mean(indata**2)))
             max_rms = max(max_rms, rms)
@@ -2062,26 +2463,43 @@ class PulseScribeDaemon:
             except queue.Full:
                 pass
 
-            if stop_event is not None and stop_event.is_set() and (
-                isinstance(callback_abort_exc, type)
-                and issubclass(callback_abort_exc, BaseException)
+            if (
+                stop_event is not None
+                and stop_event.is_set()
+                and (
+                    isinstance(callback_abort_exc, type)
+                    and issubclass(callback_abort_exc, BaseException)
+                )
             ):
                 raise callback_abort_exc
 
         # Explizites Stream-Management statt Context-Manager:
         # vermeidet PortAudio-Deadlocks beim Schließen des Streams.
-        stream = sd.InputStream(
-            samplerate=WHISPER_SAMPLE_RATE,
-            channels=1,
-            dtype="float32",
-            callback=callback,
-            finished_callback=finished_event.set,
-        )
-        self._set_worker_phase("recording:start-stream", run_id=run_id)
-        stream.start()
-        logger.debug("Audio-Stream gestartet")
+        stream = None
+        try:
+            stream = sd.InputStream(
+                samplerate=WHISPER_SAMPLE_RATE,
+                channels=1,
+                dtype="float32",
+                callback=callback,
+                finished_callback=finished_event.set,
+            )
+            self._set_worker_phase("recording:start-stream", run_id=run_id)
+            stream.start()
+        except Exception:
+            if stream is not None:
+                try:
+                    stream.close()
+                except Exception:
+                    pass
+            raise
 
         try:
+            latency_run.mark("audio_stream_started")
+            self._set_worker_phase("recording:ready-sound", run_id=run_id)
+            player.play("ready")
+            logger.debug("Audio-Stream gestartet")
+
             self._set_worker_phase("recording:capture", run_id=run_id)
             while stop_event is not None and not stop_event.is_set():
                 sd.sleep(50)
@@ -2091,6 +2509,7 @@ class PulseScribeDaemon:
                 finished_event=finished_event,
                 run_id=run_id,
             )
+            latency_run.mark("audio_stream_closed")
 
         self._set_worker_phase("recording:stop-sound", run_id=run_id)
         player.play("stop")
@@ -2103,21 +2522,29 @@ class PulseScribeDaemon:
         max_rms: float,
         had_speech: bool,
         result_queue_ref: queue.Queue[DaemonMessage | Exception],
-        run_id: int | None,
+        run_id: int,
+        latency_run: MacOSLatencyRun,
     ) -> tuple[Any, float] | None:
         import numpy as np
 
         self._set_worker_phase("recording:finalize-audio", run_id=run_id)
         if not recorded_chunks:
             logger.warning("Keine Audiodaten aufgenommen")
-            # Leeres Ergebnis signalisieren, damit Result-Polling sauber endet.
-            self._put_empty_transcript_result(result_queue_ref)
+            self._put_empty_transcript_result(
+                run_id=run_id,
+                result_queue_ref=result_queue_ref,
+                latency_run=latency_run,
+            )
             return None
         if not had_speech:
             logger.info(
                 f"Keine Sprache erkannt (max_rms={max_rms:.4f}) – Transkription übersprungen"
             )
-            self._put_empty_transcript_result(result_queue_ref)
+            self._put_empty_transcript_result(
+                run_id=run_id,
+                result_queue_ref=result_queue_ref,
+                latency_run=latency_run,
+            )
             return None
 
         audio_data = np.concatenate(recorded_chunks)
@@ -2194,6 +2621,7 @@ class PulseScribeDaemon:
         audio_duration: float,
         result_queue_ref: queue.Queue[DaemonMessage | Exception],
         run_id: int | None,
+        latency_run: MacOSLatencyRun,
     ) -> str:
         import soundfile as sf
 
@@ -2202,9 +2630,7 @@ class PulseScribeDaemon:
 
         try:
             mode_for_run = (
-                self._run_mode
-                or self.mode
-                or os.getenv("PULSESCRIBE_MODE", "deepgram")
+                self._run_mode or self.mode or os.getenv("PULSESCRIBE_MODE", "deepgram")
             )
             provider = self._get_provider(mode_for_run)
             self._log_local_preload_status(
@@ -2213,6 +2639,7 @@ class PulseScribeDaemon:
             )
 
             t0 = time.perf_counter()
+            latency_run.mark("transcribe_start")
             try:
                 self._set_worker_phase("recording:transcribing", run_id=run_id)
                 model_for_provider = self.model if mode_for_run == "local" else None
@@ -2247,6 +2674,7 @@ class PulseScribeDaemon:
                 )
                 mode_for_run = "local"
 
+            latency_run.mark_once("transcribe_done")
             self._log_transcription_performance(
                 provider=provider,
                 mode_for_run=mode_for_run,
@@ -2255,6 +2683,7 @@ class PulseScribeDaemon:
             )
             return transcript
         finally:
+            latency_run.mark_once("transcribe_done")
             if os.path.exists(temp_path):
                 os.unlink(temp_path)
 
@@ -2293,6 +2722,7 @@ class PulseScribeDaemon:
         run_id: int | None = None,
         result_queue_ref: queue.Queue[DaemonMessage | Exception] | None = None,
         stop_event: threading.Event | None = None,
+        latency_run: MacOSLatencyRun | None = None,
     ) -> None:
         """
         Standard-Aufnahme für OpenAI, Groq, Local.
@@ -2305,6 +2735,9 @@ class PulseScribeDaemon:
         run_id = self._active_run_id if run_id is None else run_id
         result_queue_ref = result_queue_ref or self._result_queue
         stop_event = stop_event or self._stop_event
+        latency_run = (
+            latency_run or self._latency_run or start_macos_latency_run(enabled=False)
+        )
 
         self._set_worker_phase("recording:boot", run_id=run_id)
         logger.debug(f"RecordingWorker gestartet (run={run_id})")
@@ -2314,6 +2747,7 @@ class PulseScribeDaemon:
                 run_id=run_id,
                 result_queue_ref=result_queue_ref,
                 stop_event=stop_event,
+                latency_run=latency_run,
             )
             prepared_audio = self._prepare_recorded_audio(
                 recorded_chunks=recorded_chunks,
@@ -2321,6 +2755,7 @@ class PulseScribeDaemon:
                 had_speech=had_speech,
                 result_queue_ref=result_queue_ref,
                 run_id=run_id,
+                latency_run=latency_run,
             )
             if prepared_audio is None:
                 return
@@ -2331,6 +2766,7 @@ class PulseScribeDaemon:
                 audio_duration=audio_duration,
                 result_queue_ref=result_queue_ref,
                 run_id=run_id,
+                latency_run=latency_run,
             )
 
             transcript = self._maybe_refine(
@@ -2338,19 +2774,31 @@ class PulseScribeDaemon:
                 phase_prefix="recording",
                 run_id=run_id,
                 result_queue=result_queue_ref,
+                latency_run=latency_run,
             )
 
             logger.debug("Sende TRANSCRIPT_RESULT")
             self._set_worker_phase("recording:publishing-result", run_id=run_id)
-            result_queue_ref.put(
-                DaemonMessage(type=MessageType.TRANSCRIPT_RESULT, payload=transcript)
+            self._publish_worker_terminal(
+                run_id=run_id,
+                result_queue_ref=result_queue_ref,
+                terminal=DaemonMessage(
+                    type=MessageType.TRANSCRIPT_RESULT,
+                    payload=transcript,
+                ),
+                latency_run=latency_run,
             )
             self._set_worker_phase("recording:finished", run_id=run_id)
 
         except Exception as e:
             logger.exception(f"Recording-Worker Fehler: {e}")
             emergency_log(f"RecordingWorker Exception: {type(e).__name__}: {e}")
-            result_queue_ref.put(e)
+            self._publish_worker_terminal(
+                run_id=run_id,
+                result_queue_ref=result_queue_ref,
+                terminal=e,
+                latency_run=latency_run,
+            )
 
     def _stop_recording(self) -> None:
         """Stoppt Aufnahme (non-blocking) und lässt Worker im Hintergrund auslaufen."""
@@ -2358,6 +2806,9 @@ class PulseScribeDaemon:
             return
 
         logger.info("Stop-Event setzen...")
+        latency_run = self._latency_run
+        if latency_run is not None:
+            latency_run.mark_once("stop_requested")
 
         self._stop_interim_polling()
 
@@ -2509,7 +2960,12 @@ class PulseScribeDaemon:
     ) -> bool:
         if isinstance(result, Exception):
             self._stop_result_polling()
-            self._handle_worker_error(result)
+            latency_run = self._latency_run
+            self._latency_run = None
+            self._terminal_claimed_run_id = self._active_run_id
+            if latency_run is not None:
+                latency_run.mark_once("result_received_main")
+            self._handle_worker_error(result, latency_run=latency_run)
             return True
 
         if not isinstance(result, DaemonMessage):
@@ -2525,8 +2981,13 @@ class PulseScribeDaemon:
 
         if result.type == MessageType.TRANSCRIPT_RESULT:
             self._stop_result_polling()
+            latency_run = self._latency_run
+            self._latency_run = None
+            self._terminal_claimed_run_id = self._active_run_id
+            if latency_run is not None:
+                latency_run.mark_once("result_received_main")
             transcript = str(result.payload or "")
-            self._handle_transcript_result(transcript)
+            self._handle_transcript_result(transcript, latency_run=latency_run)
             return True
 
         return False
@@ -2656,6 +3117,11 @@ class PulseScribeDaemon:
             # Worker stoppen falls noch aktiv
             if daemon._stop_event:
                 daemon._stop_event.set()
+            latency_run = daemon._latency_run
+            daemon._latency_run = None
+            daemon._terminal_claimed_run_id = daemon._active_run_id
+            if latency_run is not None:
+                latency_run.finish("watchdog_timeout", error_type="TimeoutError")
             daemon._mark_current_worker_abandoned("watchdog timeout")
 
             daemon._enter_error_state("Transcription timed out")
@@ -2696,11 +3162,15 @@ class PulseScribeDaemon:
         Verhindert Memory-Leaks bei Local Whisper (~500MB RAM).
         """
         # Timer stoppen
+        latency_run = self._latency_run
+        self._latency_run = None
+        if latency_run is not None:
+            latency_run.finish("shutdown")
         self._stop_interim_polling()
         self._stop_result_polling()
         self._stop_transcribing_watchdog()
         self._stop_error_reset_timer()
-        self._stop_keepalive_timer()
+        self._cancel_local_warm_lifecycle(wait=True)
 
         # Provider-Cache leeren (Local Whisper kann ~500MB RAM halten)
         with self._provider_cache_lock:
@@ -2715,13 +3185,24 @@ class PulseScribeDaemon:
                     pass
         logger.debug("Provider-Cache geleert")
 
-    def _paste_result(self, transcript: str) -> None:
+    def _paste_result(
+        self,
+        transcript: str,
+        *,
+        latency_run: MacOSLatencyRun | None = None,
+    ) -> None:
         """Fügt Transkript via Auto-Paste ein."""
-        success = paste_transcript(transcript)
-        if success:
-            logger.info(f"✓ Text eingefügt: {redacted_text_summary(transcript)}")
-        else:
-            logger.error("Auto-Paste fehlgeschlagen")
+        if latency_run is not None:
+            latency_run.mark("paste_start")
+        try:
+            success = paste_transcript(transcript)
+            if success:
+                logger.info(f"✓ Text eingefügt: {redacted_text_summary(transcript)}")
+            else:
+                logger.error("Auto-Paste fehlgeschlagen")
+        finally:
+            if latency_run is not None:
+                latency_run.mark("paste_done")
 
     def _setup_app_menu(self, app) -> None:
         """Erstellt Application Menu für CMD+Q Support."""
@@ -2864,6 +3345,7 @@ class PulseScribeDaemon:
         """Lädt Settings aus .env neu und wendet sie an."""
         from utils.preferences import read_env_file
 
+        old_mode = self.mode
         old_local_signature = self._local_provider_memory_signature()
         load_environment(override_existing=True)
         env_values = read_env_file()
@@ -2875,12 +3357,31 @@ class PulseScribeDaemon:
         self._apply_reloaded_hotkey_settings(env_values)
         self._apply_reloaded_runtime_settings(env_values)
         new_local_signature = self._local_provider_memory_signature()
-        if new_local_signature != old_local_signature:
-            self._release_local_provider_model_cache()
+        memory_changed = new_local_signature != old_local_signature
+        local_transition = old_mode != self.mode and (
+            old_mode == "local" or self.mode == "local"
+        )
+        if local_transition or (
+            memory_changed and (old_mode == "local" or self.mode == "local")
+        ):
+            self._cancel_local_warm_lifecycle()
         self._invalidate_local_provider_runtime_config()
         self._log_reloaded_settings()
         self._reconfigure_hotkeys_after_reload(old_hotkey_signature)
-        self._preload_local_model_async()
+
+        with self._local_warm_lock:
+            desired_preload_ready = (
+                self._local_preload_signature == new_local_signature
+                and self._local_preload_complete.is_set()
+            )
+            warm_generation = self._local_warm_generation
+        if memory_changed:
+            self._release_local_provider_model_cache_async(
+                generation=warm_generation,
+                preload_after=self.mode == "local",
+            )
+        elif self.mode == "local" and not desired_preload_ready:
+            self._preload_local_model_async()
 
     @staticmethod
     def _sync_reload_env_values(env_values: dict[str, str]) -> None:
@@ -2973,6 +3474,37 @@ class PulseScribeDaemon:
                 cleanup()
             except Exception as e:
                 logger.warning(f"LocalProvider cleanup fehlgeschlagen: {e}")
+
+    def _release_local_provider_model_cache_async(
+        self,
+        *,
+        generation: int,
+        preload_after: bool,
+    ) -> threading.Thread | None:
+        """Release a local model off the AppKit thread and optionally preload next."""
+
+        def _reconcile() -> None:
+            with self._local_cache_reconcile_lock:
+                with self._local_warm_lock:
+                    if generation != self._local_warm_generation:
+                        return
+                self._release_local_provider_model_cache()
+                with self._local_warm_lock:
+                    still_current = generation == self._local_warm_generation
+                if still_current and preload_after and self.mode == "local":
+                    self._preload_local_model_async()
+
+        thread = threading.Thread(
+            target=_reconcile,
+            daemon=True,
+            name="LocalModelReconcile",
+        )
+        try:
+            thread.start()
+        except Exception as exc:
+            logger.warning("Local model reconcile konnte nicht starten: %s", exc)
+            return None
+        return thread
 
     def _invalidate_local_provider_runtime_config(self) -> None:
         with self._provider_cache_lock:
@@ -3244,7 +3776,9 @@ class PulseScribeDaemon:
         hk_is_fn = hk_str == "fn"
         hk_is_capslock = hk_str in ("capslock", "caps_lock")
 
-        if not input_monitoring_granted and (mode == "hold" or hk_is_fn or hk_is_capslock):
+        if not input_monitoring_granted and (
+            mode == "hold" or hk_is_fn or hk_is_capslock
+        ):
             msg = f"Hotkey '{hk}' benötigt Eingabemonitoring‑Zugriff – deaktiviert."
             logger.warning(msg)
             return msg
@@ -3421,14 +3955,19 @@ class PulseScribeDaemon:
 
         app, show_dock = self._configure_ns_application()
         self._initialize_ui_controllers()
+        self._prewarm_audio_dependencies_async()
         self._validate_vocabulary_on_startup()
         self._show_welcome_if_needed()
         bindings_for_info = self._resolve_hotkey_bindings()
         self._log_startup_permission_status()
-        self._print_startup_info(show_dock=show_dock, bindings_for_info=bindings_for_info)
+        self._print_startup_info(
+            show_dock=show_dock, bindings_for_info=bindings_for_info
+        )
         self._preload_local_model_async()
         self._reconfigure_hotkeys(show_alerts=True)
-        self._install_runloop_shutdown_handlers(app=app, timer_cls=NSTimer, signal_mod=signal)
+        self._install_runloop_shutdown_handlers(
+            app=app, timer_cls=NSTimer, signal_mod=signal
+        )
         app.run()
 
     def _configure_ns_application(self):
@@ -3500,7 +4039,9 @@ class PulseScribeDaemon:
             print("   Beenden: Menubar-Icon → Quit oder Ctrl+C", file=sys.stderr)
 
     def _install_runloop_shutdown_handlers(self, *, app, timer_cls, signal_mod) -> None:
-        timer_cls.scheduledTimerWithTimeInterval_repeats_block_(0.1, True, lambda _: None)
+        timer_cls.scheduledTimerWithTimeInterval_repeats_block_(
+            0.1, True, lambda _: None
+        )
 
         def signal_handler(sig, frame):
             self.cleanup()
@@ -3644,7 +4185,9 @@ def _configure_default_local_backend() -> None:
 
         is_arm = platform.machine() in ("arm64", "aarch64")
         has_mlx = importlib.util.find_spec("mlx_whisper") is not None
-        os.environ["PULSESCRIBE_LOCAL_BACKEND"] = "mlx" if is_arm and has_mlx else "whisper"
+        os.environ["PULSESCRIBE_LOCAL_BACKEND"] = (
+            "mlx" if is_arm and has_mlx else "whisper"
+        )
         if is_arm and has_mlx:
             os.environ.setdefault("PULSESCRIBE_LOCAL_FAST", "true")
     except Exception:

--- a/pulsescribe_daemon.py
+++ b/pulsescribe_daemon.py
@@ -2674,6 +2674,8 @@ class PulseScribeDaemon:
                 )
                 mode_for_run = "local"
 
+            # Mark provider completion before performance-log bookkeeping; the
+            # finally marker below only fills this event when transcription raises.
             latency_run.mark_once("transcribe_done")
             self._log_transcription_performance(
                 provider=provider,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -61,6 +61,22 @@ def test_config_preload_preserves_existing_process_env(tmp_path, monkeypatch) ->
             sys.modules["config"] = original_config
 
 
+def test_bounded_float_env_rejects_nan(monkeypatch) -> None:
+    import config as config_module
+
+    monkeypatch.setenv("PULSESCRIBE_TEST_TIMEOUT", "NaN")
+
+    assert (
+        config_module._get_bounded_float_env(
+            "PULSESCRIBE_TEST_TIMEOUT",
+            1.25,
+            min_value=0.05,
+            max_value=10.0,
+        )
+        == 1.25
+    )
+
+
 def test_windows_latency_preset_defaults_to_snappy_and_safe_is_opt_out(
     monkeypatch,
 ) -> None:
@@ -113,7 +129,10 @@ def test_get_input_device_retries_after_initial_probe_failure(monkeypatch) -> No
     monkeypatch.setitem(sys.modules, "sounddevice", fake_sounddevice)
 
     try:
-        assert config_module.get_input_device() == (None, config_module.WHISPER_SAMPLE_RATE)
+        assert config_module.get_input_device() == (
+            None,
+            config_module.WHISPER_SAMPLE_RATE,
+        )
         assert config_module.get_input_device() == (None, 48_000)
         assert query_calls == 2
     finally:
@@ -147,7 +166,6 @@ def test_get_input_device_keeps_caching_successful_probe(monkeypatch) -> None:
         _restore_input_device_cache(config_module, original_cache)
 
 
-
 def test_get_input_device_non_windows_prefers_named_microphone(monkeypatch) -> None:
     import config as config_module
 
@@ -176,7 +194,6 @@ def test_get_input_device_non_windows_prefers_named_microphone(monkeypatch) -> N
         assert config_module.get_input_device() == (1, 48_000)
     finally:
         _restore_input_device_cache(config_module, original_cache)
-
 
 
 def test_get_input_device_windows_prefers_working_mic_array(monkeypatch) -> None:
@@ -233,7 +250,6 @@ def test_get_input_device_windows_prefers_working_mic_array(monkeypatch) -> None
         assert attempts == [(1, 48_000)]
     finally:
         _restore_input_device_cache(config_module, original_cache)
-
 
 
 def test_get_input_device_windows_falls_back_to_working_microphone(monkeypatch) -> None:
@@ -296,7 +312,6 @@ def test_get_input_device_windows_falls_back_to_working_microphone(monkeypatch) 
         _restore_input_device_cache(config_module, original_cache)
 
 
-
 def test_get_input_device_windows_uses_non_output_capture_before_final_fallback(
     monkeypatch,
 ) -> None:
@@ -354,7 +369,6 @@ def test_get_input_device_windows_uses_non_output_capture_before_final_fallback(
         assert attempts == [(2, 16_000)]
     finally:
         _restore_input_device_cache(config_module, original_cache)
-
 
 
 def test_get_input_device_windows_fallback_result_is_not_cached(monkeypatch) -> None:

--- a/tests/test_daemon_keepalive.py
+++ b/tests/test_daemon_keepalive.py
@@ -67,15 +67,16 @@ def test_keepalive_stops_after_local_generation_is_cancelled():
             model="large",
         )
         assert called.wait(timeout=1.0)
+        calls_before_cancel = provider.keepalive.call_count
         daemon.mode = "openai"
         keepalive_thread = daemon._keepalive_thread
         daemon._cancel_local_warm_lifecycle()
         assert keepalive_thread is not None
         keepalive_thread.join(timeout=1.0)
+        assert not keepalive_thread.is_alive()
 
-    calls_after_stop = provider.keepalive.call_count
     assert daemon._keepalive_thread is None
-    assert provider.keepalive.call_count == calls_after_stop
+    assert provider.keepalive.call_count == calls_before_cancel
 
 
 def test_blocked_old_keepalive_starts_pending_generation_after_exit():
@@ -101,7 +102,8 @@ def test_blocked_old_keepalive_starts_pending_generation_after_exit():
         )
         assert old_started.wait(timeout=1.0)
 
-        new_signature = ("local", "mlx", "turbo")
+        daemon.model = "turbo"
+        new_signature = daemon._local_provider_memory_signature()
         with daemon._local_warm_lock:
             daemon._local_warm_generation = 2
             daemon._local_preload_signature = new_signature
@@ -158,7 +160,8 @@ def test_stale_keepalive_start_cannot_overwrite_current_pending_request():
         stale_thread.start()
         assert stale_prepare_started.wait(timeout=1.0)
 
-        current_signature = ("local", "mlx", "turbo")
+        daemon.model = "turbo"
+        current_signature = daemon._local_provider_memory_signature()
         with daemon._local_warm_lock:
             daemon._local_warm_generation = 2
             daemon._local_preload_signature = current_signature

--- a/tests/test_daemon_keepalive.py
+++ b/tests/test_daemon_keepalive.py
@@ -1,0 +1,389 @@
+import threading
+from unittest.mock import MagicMock, patch
+
+from pulsescribe_daemon import PulseScribeDaemon
+
+
+class _LocalProvider:
+    _backend = "mlx"
+
+    def __init__(self):
+        self.keepalive = MagicMock()
+        self.preload = MagicMock()
+
+    def _ensure_runtime_config(self):
+        return None
+
+    def get_runtime_info(self):
+        return {"device": "mps", "compute_type": None}
+
+
+def _prime_generation(daemon: PulseScribeDaemon):
+    signature = daemon._local_provider_memory_signature()
+    with daemon._local_warm_lock:
+        daemon._local_warm_generation = 1
+        daemon._local_preload_signature = signature
+    return signature
+
+
+def test_keepalive_start_is_singleton_for_generation():
+    daemon = PulseScribeDaemon(mode="local")
+    provider = _LocalProvider()
+    signature = _prime_generation(daemon)
+
+    with patch("pulsescribe_daemon.LOCAL_KEEPALIVE_INTERVAL", 60.0):
+        assert daemon._start_keepalive_timer(
+            provider=provider,
+            generation=1,
+            signature=signature,
+            model="large",
+        )
+        first_thread = daemon._keepalive_thread
+        assert not daemon._start_keepalive_timer(
+            provider=provider,
+            generation=1,
+            signature=signature,
+            model="large",
+        )
+        assert daemon._keepalive_thread is first_thread
+        assert daemon._stop_keepalive_timer(wait=True)
+
+    assert daemon._keepalive_thread is None
+    provider.keepalive.assert_not_called()
+
+
+def test_keepalive_stops_after_local_generation_is_cancelled():
+    daemon = PulseScribeDaemon(mode="local")
+    provider = _LocalProvider()
+    signature = _prime_generation(daemon)
+    called = threading.Event()
+    provider.keepalive.side_effect = lambda _model: called.set()
+
+    with patch("pulsescribe_daemon.LOCAL_KEEPALIVE_INTERVAL", 0.01):
+        assert daemon._start_keepalive_timer(
+            provider=provider,
+            generation=1,
+            signature=signature,
+            model="large",
+        )
+        assert called.wait(timeout=1.0)
+        daemon.mode = "openai"
+        keepalive_thread = daemon._keepalive_thread
+        daemon._cancel_local_warm_lifecycle()
+        assert keepalive_thread is not None
+        keepalive_thread.join(timeout=1.0)
+
+    calls_after_stop = provider.keepalive.call_count
+    assert daemon._keepalive_thread is None
+    assert provider.keepalive.call_count == calls_after_stop
+
+
+def test_blocked_old_keepalive_starts_pending_generation_after_exit():
+    daemon = PulseScribeDaemon(mode="local")
+    old_provider = _LocalProvider()
+    new_provider = _LocalProvider()
+    old_started = threading.Event()
+    release_old = threading.Event()
+    new_started = threading.Event()
+    old_provider.keepalive.side_effect = lambda _model: (
+        old_started.set(),
+        release_old.wait(timeout=2.0),
+    )
+    new_provider.keepalive.side_effect = lambda _model: new_started.set()
+
+    old_signature = _prime_generation(daemon)
+    with patch("pulsescribe_daemon.LOCAL_KEEPALIVE_INTERVAL", 0.01):
+        assert daemon._start_keepalive_timer(
+            provider=old_provider,
+            generation=1,
+            signature=old_signature,
+            model="large",
+        )
+        assert old_started.wait(timeout=1.0)
+
+        new_signature = ("local", "mlx", "turbo")
+        with daemon._local_warm_lock:
+            daemon._local_warm_generation = 2
+            daemon._local_preload_signature = new_signature
+        assert not daemon._stop_keepalive_timer()
+        assert not daemon._start_keepalive_timer(
+            provider=new_provider,
+            generation=2,
+            signature=new_signature,
+            model="turbo",
+        )
+
+        release_old.set()
+        assert new_started.wait(timeout=1.0)
+        daemon._cancel_local_warm_lifecycle(wait=True)
+
+    assert old_provider.keepalive.call_count == 1
+    assert new_provider.keepalive.call_count >= 1
+    assert daemon._keepalive_thread is None
+
+
+def test_stale_keepalive_start_cannot_overwrite_current_pending_request():
+    daemon = PulseScribeDaemon(mode="local")
+    active_provider = _LocalProvider()
+    stale_provider = _LocalProvider()
+    current_provider = _LocalProvider()
+    stale_prepare_started = threading.Event()
+    release_stale_prepare = threading.Event()
+
+    old_signature = _prime_generation(daemon)
+    with patch("pulsescribe_daemon.LOCAL_KEEPALIVE_INTERVAL", 60.0):
+        assert daemon._start_keepalive_timer(
+            provider=active_provider,
+            generation=1,
+            signature=old_signature,
+            model="large",
+        )
+
+        def block_stale_prepare():
+            stale_prepare_started.set()
+            release_stale_prepare.wait(timeout=2.0)
+
+        stale_provider._ensure_runtime_config = block_stale_prepare
+        stale_result = []
+        stale_thread = threading.Thread(
+            target=lambda: stale_result.append(
+                daemon._start_keepalive_timer(
+                    provider=stale_provider,
+                    generation=1,
+                    signature=old_signature,
+                    model="large",
+                )
+            )
+        )
+        stale_thread.start()
+        assert stale_prepare_started.wait(timeout=1.0)
+
+        current_signature = ("local", "mlx", "turbo")
+        with daemon._local_warm_lock:
+            daemon._local_warm_generation = 2
+            daemon._local_preload_signature = current_signature
+        assert not daemon._start_keepalive_timer(
+            provider=current_provider,
+            generation=2,
+            signature=current_signature,
+            model="turbo",
+        )
+
+        release_stale_prepare.set()
+        stale_thread.join(timeout=1.0)
+        assert stale_result == [False]
+        assert daemon._pending_keepalive_request is not None
+        assert daemon._pending_keepalive_request.provider is current_provider
+
+        assert daemon._stop_keepalive_timer(wait=True)
+        assert daemon._keepalive_request is not None
+        assert daemon._keepalive_request.provider is current_provider
+        daemon._cancel_local_warm_lifecycle(wait=True)
+
+
+def test_identical_preload_is_not_started_twice():
+    daemon = PulseScribeDaemon(mode="local", model="large")
+    provider = _LocalProvider()
+    started = threading.Event()
+    release = threading.Event()
+
+    def preload(_model):
+        started.set()
+        assert release.wait(timeout=2.0)
+
+    provider.preload.side_effect = preload
+
+    with (
+        patch.object(daemon, "_get_provider", return_value=provider),
+        patch("pulsescribe_daemon.LOCAL_KEEPALIVE_INTERVAL", 0.0),
+        patch("pulsescribe_daemon.get_sound_player"),
+    ):
+        assert daemon._preload_local_model_async()
+        assert started.wait(timeout=1.0)
+        assert not daemon._preload_local_model_async()
+        release.set()
+        preload_thread = daemon._local_preload_thread
+        assert preload_thread is not None
+        preload_thread.join(timeout=2.0)
+
+    provider.preload.assert_called_once_with("large")
+    assert daemon._local_preload_complete.is_set()
+
+
+def test_stale_preload_cannot_publish_ready_or_start_keepalive():
+    daemon = PulseScribeDaemon(mode="local", model="large")
+    provider = _LocalProvider()
+    started = threading.Event()
+    release = threading.Event()
+
+    def preload(_model):
+        started.set()
+        assert release.wait(timeout=2.0)
+
+    provider.preload.side_effect = preload
+
+    with (
+        patch.object(daemon, "_get_provider", return_value=provider),
+        patch.object(daemon, "_start_keepalive_timer") as start_keepalive,
+        patch("pulsescribe_daemon.get_sound_player") as get_sound_player,
+    ):
+        assert daemon._preload_local_model_async()
+        assert started.wait(timeout=1.0)
+        preload_thread = daemon._local_preload_thread
+        daemon.mode = "openai"
+        daemon._cancel_local_warm_lifecycle()
+        release.set()
+        assert preload_thread is not None
+        preload_thread.join(timeout=2.0)
+
+    assert not daemon._local_preload_complete.is_set()
+    start_keepalive.assert_not_called()
+    get_sound_player.return_value.play.assert_not_called()
+
+
+def test_model_cache_release_runs_off_thread_and_preloads_after_completion():
+    daemon = PulseScribeDaemon(mode="local", model="large")
+    provider = MagicMock()
+    release_started = threading.Event()
+    allow_release = threading.Event()
+
+    def clear_model_cache():
+        release_started.set()
+        assert allow_release.wait(timeout=2.0)
+
+    provider.clear_model_cache.side_effect = clear_model_cache
+    daemon._provider_cache["local"] = provider
+    _prime_generation(daemon)
+
+    with patch.object(daemon, "_preload_local_model_async") as preload:
+        reconcile_thread = daemon._release_local_provider_model_cache_async(
+            generation=1,
+            preload_after=True,
+        )
+        assert reconcile_thread is not None
+        assert release_started.wait(timeout=1.0)
+        preload.assert_not_called()
+        allow_release.set()
+        reconcile_thread.join(timeout=2.0)
+
+    provider.clear_model_cache.assert_called_once_with()
+    preload.assert_called_once_with()
+
+
+def test_only_latest_queued_cache_reconcile_clears_then_preloads():
+    daemon = PulseScribeDaemon(mode="local", model="large")
+    provider = MagicMock()
+    first_clear_started = threading.Event()
+    allow_first_clear = threading.Event()
+    clear_calls = 0
+
+    def clear_model_cache():
+        nonlocal clear_calls
+        clear_calls += 1
+        if clear_calls == 1:
+            first_clear_started.set()
+            assert allow_first_clear.wait(timeout=2.0)
+
+    provider.clear_model_cache.side_effect = clear_model_cache
+    daemon._provider_cache["local"] = provider
+    with daemon._local_warm_lock:
+        daemon._local_warm_generation = 1
+
+    with patch.object(daemon, "_preload_local_model_async") as preload:
+        first = daemon._release_local_provider_model_cache_async(
+            generation=1,
+            preload_after=True,
+        )
+        assert first is not None
+        assert first_clear_started.wait(timeout=1.0)
+
+        with daemon._local_warm_lock:
+            daemon._local_warm_generation = 2
+        second = daemon._release_local_provider_model_cache_async(
+            generation=2,
+            preload_after=True,
+        )
+        with daemon._local_warm_lock:
+            daemon._local_warm_generation = 3
+        third = daemon._release_local_provider_model_cache_async(
+            generation=3,
+            preload_after=True,
+        )
+        assert second is not None and third is not None
+
+        allow_first_clear.set()
+        for thread in (first, second, third):
+            thread.join(timeout=2.0)
+
+    assert provider.clear_model_cache.call_count == 2
+    preload.assert_called_once_with()
+
+
+def _reload_with_runtime_change(daemon, change_runtime):
+    with (
+        patch("pulsescribe_daemon.load_environment"),
+        patch("utils.preferences.read_env_file", return_value={}),
+        patch.object(daemon, "_sync_reload_env_values"),
+        patch.object(daemon, "_apply_reloaded_hotkey_settings"),
+        patch.object(
+            daemon,
+            "_apply_reloaded_runtime_settings",
+            side_effect=lambda _values: change_runtime(),
+        ),
+        patch.object(daemon, "_resolve_hotkey_bindings", return_value=[]),
+        patch.object(daemon, "_invalidate_local_provider_runtime_config"),
+        patch.object(
+            daemon,
+            "_release_local_provider_model_cache_async",
+        ) as release_cache_async,
+        patch.object(daemon, "_cancel_local_warm_lifecycle") as cancel_warm,
+        patch.object(daemon, "_preload_local_model_async") as preload,
+    ):
+        daemon._reload_settings()
+    return release_cache_async, cancel_warm, preload
+
+
+def test_unrelated_settings_reload_keeps_ready_model():
+    daemon = PulseScribeDaemon(mode="local", model="large", language="de")
+    signature = daemon._local_provider_memory_signature()
+    daemon._local_preload_signature = signature
+    daemon._local_preload_complete.set()
+
+    release_cache, cancel_warm, preload = _reload_with_runtime_change(
+        daemon,
+        lambda: setattr(daemon, "language", "en"),
+    )
+
+    release_cache.assert_not_called()
+    cancel_warm.assert_not_called()
+    preload.assert_not_called()
+
+
+def test_model_change_restarts_local_warm_generation_once():
+    daemon = PulseScribeDaemon(mode="local", model="large")
+    daemon._local_preload_signature = daemon._local_provider_memory_signature()
+    daemon._local_preload_complete.set()
+
+    release_cache, cancel_warm, preload = _reload_with_runtime_change(
+        daemon,
+        lambda: setattr(daemon, "model", "turbo"),
+    )
+
+    release_cache.assert_called_once_with(generation=0, preload_after=True)
+    cancel_warm.assert_called_once_with()
+    preload.assert_not_called()
+
+
+def test_leaving_local_stops_warm_lifecycle_without_preload():
+    daemon = PulseScribeDaemon(mode="local", model="large")
+    daemon._local_preload_signature = daemon._local_provider_memory_signature()
+    daemon._local_preload_complete.set()
+
+    release_cache, cancel_warm, preload = _reload_with_runtime_change(
+        daemon,
+        lambda: setattr(daemon, "mode", "openai"),
+    )
+
+    release_cache.assert_called_once_with(generation=0, preload_after=False)
+    cancel_warm.assert_called_once_with()
+    preload.assert_not_called()

--- a/tests/test_daemon_latency_path.py
+++ b/tests/test_daemon_latency_path.py
@@ -180,6 +180,69 @@ def test_worker_terminal_is_dispatched_and_claimed_once_on_main():
     assert daemon._latency_run is None
 
 
+def test_worker_error_terminal_finishes_latency_run_on_main():
+    daemon = PulseScribeDaemon(mode="local")
+    result_queue = queue.Queue()
+    daemon._active_run_id = 8
+    daemon._result_queue = result_queue
+    daemon._worker_abandoned = False
+    run = MagicMock()
+    daemon._latency_run = run
+    terminal = RuntimeError("boom")
+    scheduled: list[object] = []
+    fake_queue = MagicMock()
+    fake_queue.addOperationWithBlock_.side_effect = scheduled.append
+    foundation = SimpleNamespace(
+        NSOperationQueue=SimpleNamespace(mainQueue=lambda: fake_queue)
+    )
+
+    with (
+        patch.dict(sys.modules, {"Foundation": foundation}),
+        patch.object(daemon, "_enter_error_state") as enter_error,
+        patch.object(daemon, "_stop_result_polling"),
+        patch("pulsescribe_daemon.emergency_log"),
+    ):
+        worker = threading.Thread(
+            target=lambda: daemon._publish_worker_terminal(
+                run_id=8,
+                result_queue_ref=result_queue,
+                terminal=terminal,
+                latency_run=run,
+            )
+        )
+        worker.start()
+        worker.join(timeout=1.0)
+        assert not worker.is_alive()
+        assert len(scheduled) == 1
+        scheduled[0]()
+
+    run.finish.assert_called_once_with("error", error_type="RuntimeError")
+    enter_error.assert_called_once()
+
+
+def test_publish_worker_terminal_falls_back_to_polling_without_foundation():
+    daemon = PulseScribeDaemon(mode="local")
+    result_queue = queue.Queue()
+    run = MagicMock()
+    terminal = DaemonMessage(type=MessageType.TRANSCRIPT_RESULT, payload="fallback")
+    foundation = SimpleNamespace()
+
+    with patch.dict(sys.modules, {"Foundation": foundation}):
+        worker = threading.Thread(
+            target=lambda: daemon._publish_worker_terminal(
+                run_id=1,
+                result_queue_ref=result_queue,
+                terminal=terminal,
+                latency_run=run,
+            )
+        )
+        worker.start()
+        worker.join(timeout=1.0)
+
+    assert not worker.is_alive()
+    assert result_queue.get_nowait() is terminal
+
+
 def test_stale_worker_terminal_cannot_update_current_run():
     daemon = PulseScribeDaemon(mode="local")
     old_queue = queue.Queue()

--- a/tests/test_daemon_latency_path.py
+++ b/tests/test_daemon_latency_path.py
@@ -1,0 +1,203 @@
+import queue
+import sys
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pulsescribe_daemon import PulseScribeDaemon
+from utils.macos_latency_diagnostics import start_macos_latency_run
+from utils.state import DaemonMessage, MessageType
+
+
+def _disabled_latency_run():
+    return start_macos_latency_run(enabled=False)
+
+
+def test_audio_dependency_prewarm_is_idempotent_and_import_only():
+    daemon = PulseScribeDaemon(mode="local")
+    imported: list[str] = []
+
+    class _ImmediateThread:
+        def __init__(self, *, target, **_kwargs):
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    with (
+        patch("pulsescribe_daemon.threading.Thread", _ImmediateThread),
+        patch(
+            "importlib.import_module",
+            side_effect=lambda name: imported.append(name) or SimpleNamespace(),
+        ),
+    ):
+        assert daemon._prewarm_audio_dependencies_async() is True
+        assert daemon._prewarm_audio_dependencies_async() is False
+
+    assert imported == ["numpy", "sounddevice", "soundfile"]
+    assert daemon._audio_prewarm_complete.is_set()
+
+
+def test_ready_sound_follows_successful_stream_start():
+    daemon = PulseScribeDaemon(mode="local")
+    stop_event = threading.Event()
+    stop_event.set()
+    calls: list[str] = []
+    stream = MagicMock()
+
+    def input_stream(**kwargs):
+        calls.append("construct")
+        stream.start.side_effect = lambda: calls.append("start")
+        stream.close.side_effect = lambda: calls.append("close")
+        kwargs["finished_callback"]()
+        return stream
+
+    sounddevice = SimpleNamespace(
+        InputStream=input_stream,
+        CallbackAbort=RuntimeError,
+        sleep=lambda _ms: None,
+    )
+    player = MagicMock()
+    player.play.side_effect = lambda name: calls.append(name)
+
+    with (
+        patch.dict(sys.modules, {"sounddevice": sounddevice}),
+        patch("pulsescribe_daemon.get_sound_player", return_value=player),
+    ):
+        daemon._capture_recording_audio(
+            run_id=1,
+            result_queue_ref=queue.Queue(),
+            stop_event=stop_event,
+            latency_run=_disabled_latency_run(),
+        )
+
+    assert calls.index("construct") < calls.index("start") < calls.index("ready")
+    assert calls[-1] == "stop"
+
+
+def test_ready_sound_failure_still_closes_started_stream():
+    daemon = PulseScribeDaemon(mode="local")
+    stop_event = threading.Event()
+    stop_event.set()
+    stream = MagicMock()
+
+    def input_stream(**kwargs):
+        stream.start.side_effect = kwargs["finished_callback"]
+        return stream
+
+    sounddevice = SimpleNamespace(
+        InputStream=input_stream,
+        CallbackAbort=RuntimeError,
+        sleep=lambda _ms: None,
+    )
+    player = MagicMock()
+    player.play.side_effect = RuntimeError("sound unavailable")
+
+    with (
+        patch.dict(sys.modules, {"sounddevice": sounddevice}),
+        patch("pulsescribe_daemon.get_sound_player", return_value=player),
+        pytest.raises(RuntimeError, match="sound unavailable"),
+    ):
+        daemon._capture_recording_audio(
+            run_id=1,
+            result_queue_ref=queue.Queue(),
+            stop_event=stop_event,
+            latency_run=_disabled_latency_run(),
+        )
+
+    stream.close.assert_called_once_with()
+
+
+def test_failed_stream_start_closes_stream_without_ready_sound():
+    daemon = PulseScribeDaemon(mode="local")
+    stream = MagicMock()
+    stream.start.side_effect = RuntimeError("device unavailable")
+    sounddevice = SimpleNamespace(
+        InputStream=lambda **_kwargs: stream,
+        CallbackAbort=RuntimeError,
+        sleep=lambda _ms: None,
+    )
+    player = MagicMock()
+
+    with (
+        patch.dict(sys.modules, {"sounddevice": sounddevice}),
+        patch("pulsescribe_daemon.get_sound_player", return_value=player),
+        pytest.raises(RuntimeError, match="device unavailable"),
+    ):
+        daemon._capture_recording_audio(
+            run_id=1,
+            result_queue_ref=queue.Queue(),
+            stop_event=threading.Event(),
+            latency_run=_disabled_latency_run(),
+        )
+
+    stream.close.assert_called_once_with()
+    player.play.assert_not_called()
+
+
+def test_worker_terminal_is_dispatched_and_claimed_once_on_main():
+    daemon = PulseScribeDaemon(mode="local")
+    result_queue = queue.Queue()
+    daemon._active_run_id = 7
+    daemon._result_queue = result_queue
+    daemon._worker_abandoned = False
+    run = MagicMock()
+    daemon._latency_run = run
+    terminal = DaemonMessage(type=MessageType.TRANSCRIPT_RESULT, payload="hello")
+    scheduled: list[object] = []
+    fake_queue = MagicMock()
+    fake_queue.addOperationWithBlock_.side_effect = scheduled.append
+    foundation = SimpleNamespace(
+        NSOperationQueue=SimpleNamespace(mainQueue=lambda: fake_queue)
+    )
+
+    with (
+        patch.dict(sys.modules, {"Foundation": foundation}),
+        patch.object(daemon, "_handle_transcript_result") as handle_result,
+        patch.object(daemon, "_stop_result_polling") as stop_polling,
+    ):
+        worker = threading.Thread(
+            target=lambda: daemon._publish_worker_terminal(
+                run_id=7,
+                result_queue_ref=result_queue,
+                terminal=terminal,
+                latency_run=run,
+            )
+        )
+        worker.start()
+        worker.join()
+
+        assert result_queue.empty()
+        assert len(scheduled) == 1
+        scheduled[0]()
+        scheduled[0]()
+
+    stop_polling.assert_called_once_with()
+    handle_result.assert_called_once_with("hello", latency_run=run)
+    assert daemon._terminal_claimed_run_id == 7
+    assert daemon._latency_run is None
+
+
+def test_stale_worker_terminal_cannot_update_current_run():
+    daemon = PulseScribeDaemon(mode="local")
+    old_queue = queue.Queue()
+    daemon._active_run_id = 2
+    daemon._result_queue = queue.Queue()
+    run = MagicMock()
+    terminal = DaemonMessage(type=MessageType.TRANSCRIPT_RESULT, payload="stale")
+
+    with patch.object(daemon, "_handle_transcript_result") as handle_result:
+        assert (
+            daemon._claim_and_handle_worker_terminal(
+                run_id=1,
+                result_queue_ref=old_queue,
+                terminal=terminal,
+                latency_run=run,
+            )
+            is False
+        )
+
+    handle_result.assert_not_called()
+    run.finish.assert_called_once_with("stale")

--- a/tests/test_daemon_mode.py
+++ b/tests/test_daemon_mode.py
@@ -167,7 +167,7 @@ class TestDaemonMode(unittest.TestCase):
             self.assertIn("local", daemon._provider_cache)
             local_provider.invalidate_runtime_config.assert_called_once()
 
-    def test_reload_settings_releases_local_model_cache_when_memory_env_removed(self):
+    def test_reload_settings_schedules_model_release_when_memory_env_removed(self):
         daemon = PulseScribeDaemon(mode="local")
         local_provider = MagicMock()
         daemon._provider_cache["local"] = local_provider
@@ -184,12 +184,16 @@ class TestDaemonMode(unittest.TestCase):
             patch("pulsescribe_daemon.load_environment"),
             patch("utils.preferences.read_env_file", return_value={}),
             patch.object(daemon, "_preload_local_model_async"),
+            patch.object(
+                daemon,
+                "_release_local_provider_model_cache_async",
+            ) as release_async,
         ):
             daemon._reload_settings()
 
         self.assertNotIn("PULSESCRIBE_LOCAL_COMPUTE_TYPE", os.environ)
         self.assertNotIn("PULSESCRIBE_LIGHTNING_BATCH_SIZE", os.environ)
-        local_provider.clear_model_cache.assert_called_once_with()
+        release_async.assert_called_once_with(generation=1, preload_after=True)
         local_provider.invalidate_runtime_config.assert_called_once_with()
 
     def test_provider_cache_is_thread_safe_during_reload(self):
@@ -413,7 +417,9 @@ class TestDaemonMode(unittest.TestCase):
         self.assertIsNotNone(result_msg)
         self.assertEqual(result_msg.payload, "")
 
-    def test_handle_transcript_result_uses_no_speech_feedback_for_empty_transcript(self):
+    def test_handle_transcript_result_uses_no_speech_feedback_for_empty_transcript(
+        self,
+    ):
         daemon = PulseScribeDaemon(mode="openai")
 
         with (
@@ -425,7 +431,7 @@ class TestDaemonMode(unittest.TestCase):
         ):
             daemon._handle_transcript_result("")
 
-        mock_no_speech.assert_called_once_with()
+        mock_no_speech.assert_called_once_with(latency_run=None)
         mock_apply_pending.assert_not_called()
 
     def test_recording_worker_local_keeps_trailing_audio_and_pads_tail(self):
@@ -748,11 +754,9 @@ class TestWatchdogTimer(unittest.TestCase):
             patch("pulsescribe_daemon.get_sound_player") as mock_get_sound_player,
         ):
             daemon._start_transcribing_watchdog()
-            watchdog_cb = (
-                mock_timer_cls.scheduledTimerWithTimeInterval_repeats_block_.call_args_list[
-                    0
-                ][0][2]
-            )
+            watchdog_cb = mock_timer_cls.scheduledTimerWithTimeInterval_repeats_block_.call_args_list[
+                0
+            ][0][2]
             watchdog_cb(None)
 
         self.assertTrue(daemon._worker_abandoned)

--- a/tests/test_deepgram_stream.py
+++ b/tests/test_deepgram_stream.py
@@ -1064,6 +1064,195 @@ def _graceful_shutdown_tasks(audio_queue):
     return _send_worker, _listen_worker
 
 
+def test_finalize_send_timeout_skips_ack_wait_and_still_closes(monkeypatch) -> None:
+    class _FakeControlMessage:
+        def __init__(self, type: str) -> None:
+            self.type = type
+
+    monkeypatch.setitem(
+        sys.modules,
+        "deepgram.extensions.types.sockets",
+        SimpleNamespace(ListenV1ControlMessage=_FakeControlMessage),
+    )
+    monkeypatch.setattr(deepgram_stream, "DEEPGRAM_TAIL_PADDING_SECONDS", 0.0)
+    monkeypatch.setattr(deepgram_stream, "DEEPGRAM_FINALIZE_SEND_TIMEOUT", 0.01)
+    monkeypatch.setattr(deepgram_stream, "DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT", 0.01)
+
+    async def _run() -> tuple[list[str], list[str], bool]:
+        state = deepgram_stream.StreamState()
+        audio_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+        send_worker, listen_worker = _graceful_shutdown_tasks(audio_queue)
+        send_task = asyncio.create_task(send_worker())
+        listen_task = asyncio.create_task(listen_worker())
+        controls: list[str] = []
+        events: list[str] = []
+
+        class _Connection:
+            async def send_control(self, message) -> None:
+                controls.append(message.type)
+                if message.type == "Finalize":
+                    await asyncio.Event().wait()
+
+        await asyncio.wait_for(
+            deepgram_stream._graceful_shutdown(
+                connection=cast(Any, _Connection()),
+                state=state,
+                audio_queue=audio_queue,
+                send_task=send_task,
+                listen_task=listen_task,
+                session_id="sess",
+                latency_event_callback=lambda name, _fields=None: events.append(name),
+            ),
+            timeout=0.5,
+        )
+        return controls, events, listen_task.done()
+
+    controls, events, listener_done = asyncio.run(_run())
+    assert controls == ["Finalize", "CloseStream"]
+    assert "deepgram_finalize_send_timeout" in events
+    assert "deepgram_finalize_timeout" not in events
+    assert listener_done
+
+
+def test_close_stream_send_timeout_still_cancels_listener(monkeypatch) -> None:
+    class _FakeControlMessage:
+        def __init__(self, type: str) -> None:
+            self.type = type
+
+    monkeypatch.setitem(
+        sys.modules,
+        "deepgram.extensions.types.sockets",
+        SimpleNamespace(ListenV1ControlMessage=_FakeControlMessage),
+    )
+    monkeypatch.setattr(deepgram_stream, "DEEPGRAM_TAIL_PADDING_SECONDS", 0.0)
+    monkeypatch.setattr(deepgram_stream, "DEEPGRAM_FINALIZE_SEND_TIMEOUT", 0.01)
+    monkeypatch.setattr(deepgram_stream, "DEEPGRAM_CLOSE_STREAM_SEND_TIMEOUT", 0.01)
+
+    async def _run() -> tuple[list[str], bool]:
+        state = deepgram_stream.StreamState()
+        audio_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+        send_worker, listen_worker = _graceful_shutdown_tasks(audio_queue)
+        send_task = asyncio.create_task(send_worker())
+        listen_task = asyncio.create_task(listen_worker())
+        events: list[str] = []
+
+        class _Connection:
+            async def send_control(self, message) -> None:
+                if message.type == "Finalize":
+                    state.finalize_done.set()
+                    return
+                await asyncio.Event().wait()
+
+        await asyncio.wait_for(
+            deepgram_stream._graceful_shutdown(
+                connection=cast(Any, _Connection()),
+                state=state,
+                audio_queue=audio_queue,
+                send_task=send_task,
+                listen_task=listen_task,
+                session_id="sess",
+                latency_event_callback=lambda name, _fields=None: events.append(name),
+            ),
+            timeout=0.5,
+        )
+        return events, listen_task.done()
+
+    events, listener_done = asyncio.run(_run())
+    assert "deepgram_close_send_timeout" in events
+    assert listener_done
+
+
+def test_graceful_shutdown_cancellation_reaps_stream_tasks(monkeypatch) -> None:
+    class _FakeControlMessage:
+        def __init__(self, type: str) -> None:
+            self.type = type
+
+    monkeypatch.setitem(
+        sys.modules,
+        "deepgram.extensions.types.sockets",
+        SimpleNamespace(ListenV1ControlMessage=_FakeControlMessage),
+    )
+    monkeypatch.setattr(deepgram_stream, "DEEPGRAM_TAIL_PADDING_SECONDS", 0.0)
+    monkeypatch.setattr(deepgram_stream, "DEEPGRAM_FINALIZE_SEND_TIMEOUT", 10.0)
+
+    async def _run() -> tuple[bool, bool]:
+        state = deepgram_stream.StreamState()
+        audio_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+        send_worker, listen_worker = _graceful_shutdown_tasks(audio_queue)
+        send_task = asyncio.create_task(send_worker())
+        listen_task = asyncio.create_task(listen_worker())
+        finalize_started = asyncio.Event()
+
+        class _Connection:
+            async def send_control(self, message) -> None:
+                if message.type == "Finalize":
+                    finalize_started.set()
+                    await asyncio.Event().wait()
+
+        shutdown_task = asyncio.create_task(
+            deepgram_stream._graceful_shutdown(
+                connection=cast(Any, _Connection()),
+                state=state,
+                audio_queue=audio_queue,
+                send_task=send_task,
+                listen_task=listen_task,
+                session_id="sess",
+            )
+        )
+        await asyncio.wait_for(finalize_started.wait(), timeout=0.5)
+        shutdown_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await shutdown_task
+        return send_task.done(), listen_task.done()
+
+    assert asyncio.run(_run()) == (True, True)
+
+
+def test_warm_keepalive_timeout_discards_and_reconnects(monkeypatch) -> None:
+    monkeypatch.setattr(deepgram_stream, "DEEPGRAM_KEEPALIVE_SEND_TIMEOUT", 0.01)
+
+    async def _run() -> tuple[int, int]:
+        manager = deepgram_stream.DeepgramWarmConnectionManager(keepalive_interval=0.01)
+        config = deepgram_stream.DeepgramConnectionConfig(
+            api_key="test",
+            model="nova-3",
+            language="de",
+            sample_rate=16000,
+        )
+        exit_calls = 0
+        reconnect_calls = 0
+
+        class _Connection:
+            async def send_control(self, _message) -> None:
+                await asyncio.Event().wait()
+
+        class _Context:
+            async def __aexit__(self, *_args) -> None:
+                nonlocal exit_calls
+                exit_calls += 1
+
+        prepared = deepgram_stream._PreparedDeepgramConnection(
+            config=config,
+            context=cast(Any, _Context()),
+            connection=cast(Any, _Connection()),
+        )
+        manager._prepared = prepared
+        manager._enabled = True
+        manager._desired_config = config
+
+        async def _request_prewarm(requested_config) -> None:
+            nonlocal reconnect_calls
+            assert requested_config == config
+            reconnect_calls += 1
+
+        monkeypatch.setattr(manager, "_request_prewarm", _request_prewarm)
+        await asyncio.wait_for(manager._keepalive(prepared), timeout=0.5)
+        assert manager._prepared is None
+        return exit_calls, reconnect_calls
+
+    assert asyncio.run(_run()) == (1, 1)
+
+
 def test_empty_finalize_grace_exits_early_on_late_final(monkeypatch) -> None:
     """Ein spätes Final-Transkript beendet die Empty-Finalize-Grace sofort.
 

--- a/tests/test_deepgram_stream.py
+++ b/tests/test_deepgram_stream.py
@@ -1064,7 +1064,7 @@ def _graceful_shutdown_tasks(audio_queue):
     return _send_worker, _listen_worker
 
 
-def test_finalize_send_timeout_skips_ack_wait_and_still_closes(monkeypatch) -> None:
+def test_finalize_send_timeout_skips_ack_wait_and_close_stream(monkeypatch) -> None:
     class _FakeControlMessage:
         def __init__(self, type: str) -> None:
             self.type = type
@@ -1108,9 +1108,10 @@ def test_finalize_send_timeout_skips_ack_wait_and_still_closes(monkeypatch) -> N
         return controls, events, listen_task.done()
 
     controls, events, listener_done = asyncio.run(_run())
-    assert controls == ["Finalize", "CloseStream"]
+    assert controls == ["Finalize"]
     assert "deepgram_finalize_send_timeout" in events
     assert "deepgram_finalize_timeout" not in events
+    assert "deepgram_close_send_skipped" in events
     assert listener_done
 
 
@@ -1208,7 +1209,11 @@ def test_graceful_shutdown_cancellation_reaps_stream_tasks(monkeypatch) -> None:
     assert asyncio.run(_run()) == (True, True)
 
 
-def test_warm_keepalive_timeout_discards_and_reconnects(monkeypatch) -> None:
+def test_warm_keepalive_timeout_discards_and_reconnects(
+    monkeypatch,
+    caplog,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger=deepgram_stream.logger.name)
     monkeypatch.setattr(deepgram_stream, "DEEPGRAM_KEEPALIVE_SEND_TIMEOUT", 0.01)
 
     async def _run() -> tuple[int, int]:
@@ -1251,6 +1256,7 @@ def test_warm_keepalive_timeout_discards_and_reconnects(monkeypatch) -> None:
         return exit_calls, reconnect_calls
 
     assert asyncio.run(_run()) == (1, 1)
+    assert "KeepAlive Timeout" in caplog.text
 
 
 def test_empty_finalize_grace_exits_early_on_late_final(monkeypatch) -> None:

--- a/tests/test_macos_latency_diagnostics.py
+++ b/tests/test_macos_latency_diagnostics.py
@@ -1,0 +1,132 @@
+import json
+import threading
+from unittest.mock import patch
+
+from utils.macos_latency_diagnostics import (
+    MacOSLatencyRun,
+    diagnostics_enabled,
+    start_macos_latency_run,
+)
+
+
+def test_diagnostics_are_opt_in(monkeypatch):
+    monkeypatch.delenv("PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS", raising=False)
+    assert diagnostics_enabled() is False
+
+    monkeypatch.setenv("PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS", "true")
+    with patch("utils.macos_latency_diagnostics.sys.platform", "darwin"):
+        assert diagnostics_enabled() is True
+
+
+def test_disabled_run_is_noop_and_does_not_write(tmp_path):
+    path = tmp_path / "latency.jsonl"
+    run = start_macos_latency_run(enabled=False, log_path=path)
+
+    run.mark("hotkey_accepted")
+    assert run.finish("success") is None
+    assert not path.exists()
+
+
+def test_summary_has_stable_durations_and_mark_once(tmp_path):
+    path = tmp_path / "latency.jsonl"
+    clock = iter([10.0, 10.010, 10.020, 10.050, 10.080, 10.100])
+
+    with (
+        patch("utils.macos_latency_diagnostics.time.perf_counter", side_effect=clock),
+        patch.dict(
+            "os.environ",
+            {"PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_FILE": "true"},
+        ),
+    ):
+        run = MacOSLatencyRun(
+            enabled=True,
+            mode="local",
+            streaming=False,
+            log_path=path,
+        )
+        run.mark("hotkey_accepted")
+        run.mark_once("audio_stream_started")
+        run.mark_once("audio_stream_started")
+        run.mark("stop_requested")
+        run.mark("paste_done")
+        summary = run.finish("success")
+
+    assert summary is not None
+    assert summary["durations_ms"]["hotkey_to_audio_ready"] == 10.0
+    assert summary["durations_ms"]["release_to_paste_done"] == 30.0
+    assert summary["durations_ms"]["end_to_end"] == 90.0
+    assert [event["name"] for event in summary["events"]].count(
+        "audio_stream_started"
+    ) == 1
+    assert run.finish("success") is None
+
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert written["durations_ms"] == summary["durations_ms"]
+
+
+def test_event_fields_drop_text_bearing_values(tmp_path):
+    path = tmp_path / "latency.jsonl"
+    secret = "private transcript text"
+    run = MacOSLatencyRun(enabled=True, log_path=path)
+
+    run.mark(
+        "provider_event",
+        transcript=secret,
+        application="Mail",
+        elapsed_ms=12.5,
+        cached=True,
+    )
+    run.finish("error", error_type="RuntimeError")
+
+    serialized = path.read_text(encoding="utf-8")
+    assert secret not in serialized
+    assert "Mail" not in serialized
+    summary = json.loads(serialized)
+    assert summary["events"][0]["fields"] == {
+        "cached": True,
+        "elapsed_ms": 12.5,
+    }
+    assert summary["error_type"] == "RuntimeError"
+
+
+def test_mark_once_and_finish_are_atomic_across_threads(tmp_path):
+    path = tmp_path / "latency.jsonl"
+    run = MacOSLatencyRun(enabled=True, log_path=path)
+    mark_barrier = threading.Barrier(8)
+
+    def mark_once():
+        mark_barrier.wait()
+        run.mark_once("first_audio_callback")
+
+    mark_threads = [threading.Thread(target=mark_once) for _ in range(8)]
+    for thread in mark_threads:
+        thread.start()
+    for thread in mark_threads:
+        thread.join()
+
+    finish_barrier = threading.Barrier(8)
+    results = []
+
+    def finish():
+        finish_barrier.wait()
+        results.append(run.finish("success"))
+
+    finish_threads = [threading.Thread(target=finish) for _ in range(8)]
+    for thread in finish_threads:
+        thread.start()
+    for thread in finish_threads:
+        thread.join()
+
+    assert sum(result is not None for result in results) == 1
+    summary = next(result for result in results if result is not None)
+    assert [event["name"] for event in summary["events"]].count(
+        "first_audio_callback"
+    ) == 1
+    assert len(path.read_text(encoding="utf-8").splitlines()) == 1
+
+
+def test_jsonl_write_failure_is_non_fatal(tmp_path):
+    run = MacOSLatencyRun(enabled=True, log_path=tmp_path)
+    run.mark("hotkey_accepted")
+
+    assert run.finish("error", error_type="OSError") is not None

--- a/tests/test_macos_latency_diagnostics.py
+++ b/tests/test_macos_latency_diagnostics.py
@@ -18,6 +18,12 @@ def test_diagnostics_are_opt_in(monkeypatch):
         assert diagnostics_enabled() is True
 
 
+def test_diagnostics_stay_disabled_off_macos(monkeypatch):
+    monkeypatch.setenv("PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS", "true")
+    with patch("utils.macos_latency_diagnostics.sys.platform", "linux"):
+        assert diagnostics_enabled() is False
+
+
 def test_disabled_run_is_noop_and_does_not_write(tmp_path):
     path = tmp_path / "latency.jsonl"
     run = start_macos_latency_run(enabled=False, log_path=path)
@@ -64,7 +70,8 @@ def test_summary_has_stable_durations_and_mark_once(tmp_path):
     assert written["durations_ms"] == summary["durations_ms"]
 
 
-def test_event_fields_drop_text_bearing_values(tmp_path):
+def test_event_fields_drop_text_bearing_values(tmp_path, monkeypatch):
+    monkeypatch.setenv("PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_FILE", "true")
     path = tmp_path / "latency.jsonl"
     secret = "private transcript text"
     run = MacOSLatencyRun(enabled=True, log_path=path)
@@ -89,7 +96,8 @@ def test_event_fields_drop_text_bearing_values(tmp_path):
     assert summary["error_type"] == "RuntimeError"
 
 
-def test_mark_once_and_finish_are_atomic_across_threads(tmp_path):
+def test_mark_once_and_finish_are_atomic_across_threads(tmp_path, monkeypatch):
+    monkeypatch.setenv("PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_FILE", "true")
     path = tmp_path / "latency.jsonl"
     run = MacOSLatencyRun(enabled=True, log_path=path)
     mark_barrier = threading.Barrier(8)
@@ -122,10 +130,30 @@ def test_mark_once_and_finish_are_atomic_across_threads(tmp_path):
     assert [event["name"] for event in summary["events"]].count(
         "first_audio_callback"
     ) == 1
+    timestamps = [event["t_ms"] for event in summary["events"]]
+    assert timestamps == sorted(timestamps)
+    assert all(event["dt_ms"] >= 0 for event in summary["events"])
     assert len(path.read_text(encoding="utf-8").splitlines()) == 1
 
 
-def test_jsonl_write_failure_is_non_fatal(tmp_path):
+def test_jsonl_rotates_before_exceeding_maximum(tmp_path, monkeypatch):
+    monkeypatch.setenv("PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_FILE", "true")
+    path = tmp_path / "latency.jsonl"
+    path.write_text("x" * 995, encoding="utf-8")
+
+    with patch("utils.macos_latency_diagnostics._MAX_LOG_BYTES", 1_000):
+        run = MacOSLatencyRun(enabled=True, log_path=path)
+        run.mark("hotkey_accepted")
+        run.finish("success")
+
+    assert path.with_name("latency.jsonl.1").stat().st_size == 995
+    active_record = path.read_text(encoding="utf-8")
+    assert len(active_record) < 1_000
+    assert json.loads(active_record)["run_id"] == run.run_id
+
+
+def test_jsonl_write_failure_is_non_fatal(tmp_path, monkeypatch):
+    monkeypatch.setenv("PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_FILE", "true")
     run = MacOSLatencyRun(enabled=True, log_path=tmp_path)
     run.mark("hotkey_accepted")
 

--- a/utils/macos_latency_diagnostics.py
+++ b/utils/macos_latency_diagnostics.py
@@ -1,0 +1,255 @@
+"""Opt-in, privacy-safe latency diagnostics for the macOS daemon.
+
+The tracer records monotonic relative timings and small numeric/boolean metadata.
+It never records audio, transcript/clipboard text, prompts, hotkeys, application
+names, or API credentials. Enable it with
+``PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS=true``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from utils.env import parse_bool
+from utils.timing import format_duration
+
+_ENABLE_ENV = "PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS"
+_FILE_ENV = "PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_FILE"
+_PATH_ENV = "PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_PATH"
+_DEFAULT_LOG_FILENAME = "macos_latency.jsonl"
+
+_SUMMARY_PAIRS = {
+    "hotkey_to_audio_ready": ("hotkey_accepted", "audio_stream_started"),
+    "hotkey_to_first_audio": ("hotkey_accepted", "first_audio_callback"),
+    "release_to_transcribe_start": ("stop_requested", "transcribe_start"),
+    "transcribe_duration": ("transcribe_start", "transcribe_done"),
+    "refine_duration": ("refine_start", "refine_done"),
+    "result_publish_to_main": ("result_published", "result_received_main"),
+    "result_to_paste_done": ("result_received_main", "paste_done"),
+    "paste_duration": ("paste_start", "paste_done"),
+    "history_duration": ("history_start", "history_done"),
+    "release_to_paste_done": ("stop_requested", "paste_done"),
+    "end_to_end": ("hotkey_accepted", "finish"),
+}
+
+
+def _env_bool(name: str, *, default: bool) -> bool:
+    parsed = parse_bool(os.getenv(name))
+    return default if parsed is None else parsed
+
+
+def diagnostics_enabled() -> bool:
+    """Return whether macOS latency diagnostics are enabled."""
+    return sys.platform == "darwin" and _env_bool(_ENABLE_ENV, default=False)
+
+
+def _default_log_path() -> Path:
+    override = (os.getenv(_PATH_ENV) or "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".pulsescribe" / "logs" / _DEFAULT_LOG_FILENAME
+
+
+def _safe_fields(fields: dict[str, Any]) -> dict[str, int | float | bool | None]:
+    """Keep only scalar non-text metadata in event payloads."""
+    return {
+        str(key): value
+        for key, value in fields.items()
+        if value is None or isinstance(value, (int, float, bool))
+    }
+
+
+class MacOSLatencyRun:
+    """Thread-safe trace for one accepted macOS recording run."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        mode: str | None = None,
+        streaming: bool | None = None,
+        logger: logging.Logger | None = None,
+        log_path: Path | None = None,
+    ) -> None:
+        self.enabled = enabled
+        self.run_id = uuid.uuid4().hex[:8]
+        self.mode = mode
+        self.streaming = streaming
+        self._logger = logger or logging.getLogger("pulsescribe")
+        self._log_path = log_path if log_path is not None else _default_log_path()
+        self._write_file = _env_bool(_FILE_ENV, default=True)
+        self._start = time.perf_counter()
+        self._events: list[dict[str, Any]] = []
+        self._event_names: set[str] = set()
+        self._finished = False
+        self._lock = threading.Lock()
+
+    def _append_event_locked(
+        self,
+        name: str,
+        *,
+        now: float,
+        fields: dict[str, Any],
+    ) -> None:
+        previous = self._events[-1]["t_ms"] if self._events else 0.0
+        t_ms = (now - self._start) * 1000
+        event: dict[str, Any] = {
+            "name": name,
+            "t_ms": round(t_ms, 3),
+            "dt_ms": round(t_ms - previous, 3),
+        }
+        safe_fields = _safe_fields(fields)
+        if safe_fields:
+            event["fields"] = safe_fields
+        self._events.append(event)
+        self._event_names.add(name)
+
+    def mark(self, name: str, **fields: Any) -> None:
+        """Record an event relative to run start."""
+        if not self.enabled:
+            return
+
+        now = time.perf_counter()
+        with self._lock:
+            if self._finished:
+                return
+            self._append_event_locked(name, now=now, fields=fields)
+
+    def mark_once(self, name: str, **fields: Any) -> None:
+        """Record an event only once."""
+        if not self.enabled:
+            return
+        with self._lock:
+            if self._finished or name in self._event_names:
+                return
+            self._append_event_locked(
+                name,
+                now=time.perf_counter(),
+                fields=fields,
+            )
+
+    def event(self, name: str, fields: dict[str, Any] | None = None) -> None:
+        """Callback adapter for lower-level provider latency events."""
+        self.mark(name, **(fields or {}))
+
+    def finish(
+        self,
+        outcome: str,
+        *,
+        error_type: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Finalize and emit the run summary. Repeated calls are no-ops."""
+        if not self.enabled:
+            return None
+
+        now = time.perf_counter()
+        with self._lock:
+            if self._finished:
+                return None
+            self._append_event_locked("finish", now=now, fields={})
+            self._finished = True
+            summary = self._build_summary(outcome=outcome, error_type=error_type)
+        self._log_summary(summary)
+        if self._write_file:
+            self._append_jsonl(summary)
+        return summary
+
+    def _event_time_map(self) -> dict[str, float]:
+        return {event["name"]: float(event["t_ms"]) for event in self._events}
+
+    def _durations(self) -> dict[str, float]:
+        times = self._event_time_map()
+        durations: dict[str, float] = {}
+        for label, (start_event, end_event) in _SUMMARY_PAIRS.items():
+            if start_event in times and end_event in times:
+                durations[label] = round(times[end_event] - times[start_event], 3)
+        return durations
+
+    def _build_summary(
+        self,
+        *,
+        outcome: str,
+        error_type: str | None,
+    ) -> dict[str, Any]:
+        total_ms = self._events[-1]["t_ms"] if self._events else 0.0
+        summary: dict[str, Any] = {
+            "run_id": self.run_id,
+            "outcome": outcome,
+            "mode": self.mode,
+            "streaming": self.streaming,
+            "total_ms": total_ms,
+            "durations_ms": self._durations(),
+            "events": list(self._events),
+        }
+        if error_type:
+            summary["error_type"] = error_type
+        return summary
+
+    def _log_summary(self, summary: dict[str, Any]) -> None:
+        durations = summary.get("durations_ms", {})
+        details = (
+            ", ".join(
+                f"{name}={format_duration(value)}"
+                for name, value in durations.items()
+                if isinstance(value, (int, float))
+            )
+            or "no paired durations"
+        )
+        total = summary.get("total_ms", 0.0)
+        self._logger.info(
+            "macOS latency run=%s outcome=%s mode=%s streaming=%s total=%s %s",
+            summary.get("run_id"),
+            summary.get("outcome"),
+            summary.get("mode"),
+            summary.get("streaming"),
+            format_duration(float(total) if isinstance(total, (int, float)) else 0.0),
+            details,
+        )
+
+    def _append_jsonl(self, summary: dict[str, Any]) -> None:
+        try:
+            self._log_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._log_path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(summary, ensure_ascii=False, sort_keys=True))
+                handle.write("\n")
+        except OSError as exc:
+            self._logger.debug("macOS latency diagnostics write failed: %s", exc)
+
+
+_DISABLED_RUN = MacOSLatencyRun(enabled=False)
+
+
+def start_macos_latency_run(
+    *,
+    mode: str | None = None,
+    streaming: bool | None = None,
+    logger: logging.Logger | None = None,
+    enabled: bool | None = None,
+    log_path: Path | None = None,
+) -> MacOSLatencyRun:
+    """Create a run, returning a shared no-op tracer when disabled."""
+    is_enabled = diagnostics_enabled() if enabled is None else enabled
+    if not is_enabled:
+        return _DISABLED_RUN
+    return MacOSLatencyRun(
+        enabled=True,
+        mode=mode,
+        streaming=streaming,
+        logger=logger,
+        log_path=log_path,
+    )
+
+
+__all__ = [
+    "MacOSLatencyRun",
+    "diagnostics_enabled",
+    "start_macos_latency_run",
+]

--- a/utils/macos_latency_diagnostics.py
+++ b/utils/macos_latency_diagnostics.py
@@ -25,6 +25,8 @@ _ENABLE_ENV = "PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS"
 _FILE_ENV = "PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_FILE"
 _PATH_ENV = "PULSESCRIBE_MACOS_LATENCY_DIAGNOSTICS_PATH"
 _DEFAULT_LOG_FILENAME = "macos_latency.jsonl"
+_MAX_LOG_BYTES = 1_000_000
+_FILE_WRITE_LOCK = threading.Lock()
 
 _SUMMARY_PAIRS = {
     "hotkey_to_audio_ready": ("hotkey_accepted", "audio_stream_started"),
@@ -117,11 +119,14 @@ class MacOSLatencyRun:
         if not self.enabled:
             return
 
-        now = time.perf_counter()
         with self._lock:
             if self._finished:
                 return
-            self._append_event_locked(name, now=now, fields=fields)
+            self._append_event_locked(
+                name,
+                now=time.perf_counter(),
+                fields=fields,
+            )
 
     def mark_once(self, name: str, **fields: Any) -> None:
         """Record an event only once."""
@@ -150,11 +155,14 @@ class MacOSLatencyRun:
         if not self.enabled:
             return None
 
-        now = time.perf_counter()
         with self._lock:
             if self._finished:
                 return None
-            self._append_event_locked("finish", now=now, fields={})
+            self._append_event_locked(
+                "finish",
+                now=time.perf_counter(),
+                fields={},
+            )
             self._finished = True
             summary = self._build_summary(outcome=outcome, error_type=error_type)
         self._log_summary(summary)
@@ -215,11 +223,23 @@ class MacOSLatencyRun:
         )
 
     def _append_jsonl(self, summary: dict[str, Any]) -> None:
+        encoded = json.dumps(summary, ensure_ascii=False, sort_keys=True) + "\n"
         try:
-            self._log_path.parent.mkdir(parents=True, exist_ok=True)
-            with self._log_path.open("a", encoding="utf-8") as handle:
-                handle.write(json.dumps(summary, ensure_ascii=False, sort_keys=True))
-                handle.write("\n")
+            with _FILE_WRITE_LOCK:
+                self._log_path.parent.mkdir(parents=True, exist_ok=True)
+                try:
+                    current_size = self._log_path.stat().st_size
+                except FileNotFoundError:
+                    current_size = 0
+                if (
+                    current_size > 0
+                    and current_size + len(encoded.encode("utf-8")) > _MAX_LOG_BYTES
+                ):
+                    rotated_path = self._log_path.with_name(f"{self._log_path.name}.1")
+                    rotated_path.unlink(missing_ok=True)
+                    self._log_path.replace(rotated_path)
+                with self._log_path.open("a", encoding="utf-8") as handle:
+                    handle.write(encoded)
         except OSError as exc:
             self._logger.debug("macOS latency diagnostics write failed: %s", exc)
 


### PR DESCRIPTION
## Summary

- make local model preload/keepalive generation-safe, non-duplicating, and non-blocking during settings reconciliation
- preload the macOS audio import stack and emit Ready only after the input stream is active
- dispatch terminal worker results/errors directly to the AppKit main queue with stale-run protection
- add opt-in privacy-safe macOS end-to-end JSONL latency diagnostics
- bound Deepgram Finalize, CloseStream, and warm KeepAlive control sends with cancellation-safe cleanup

## Validation

- `python -m pytest -q` — 1389 passed, 6 skipped
- `python -m pyright` — 0 errors
- `ruff check .`
- `ruff format --check` for all changed Python files
- independent fresh-context reviews completed; all confirmed medium findings fixed and re-reviewed

## Residual validation gaps

- no real microphone/WindowServer timing run was performed
- no live Deepgram network timeout was induced; timeout paths use causal fake connections
- Windows shared-provider regressions were exercised through the Windows test suites on macOS, not Windows hardware

## Summary by Sourcery

Improve macOS dictation end-to-end latency and robustness across local and Deepgram streaming modes.

New Features:
- Add opt-in macOS latency diagnostics that record privacy-safe end-to-end timing traces.
- Introduce asynchronous audio stack prewarming on macOS so the Ready state only appears after input streams are active.

Enhancements:
- Refine local model preload and keepalive lifecycle to be generation-aware, non-duplicating, and resilient to settings reloads.
- Dispatch worker terminal results and errors directly to the AppKit main queue with stale-run protection, reducing UI latency.
- Add bounded timeouts and cleanup guarantees around Deepgram control messages and graceful shutdown to avoid hangs.
- Tighten ENV float parsing by rejecting NaN values and documenting new Deepgram timeout and macOS diagnostics options.

Tests:
- Add comprehensive tests for Deepgram shutdown/keepalive timeouts and cancellation behaviour.
- Add new test suites covering local keepalive/preload generation management, macOS latency tracing, and audio stream startup sequencing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional, privacy-safe macOS latency diagnostics with JSONL output and configurable file locations.
  * Added configurable timeouts for Deepgram finalize, close-stream, and keepalive controls.
  * Improved audio startup readiness and local model warmup lifecycle management.

* **Bug Fixes**
  * Improved reliability when Deepgram control messages time out or connections shut down.
  * Invalid `NaN` configuration values now safely fall back to defaults.

* **Documentation**
  * Documented the new Deepgram timeout and macOS diagnostics settings in English and German configuration guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->