### PR TITLE
Fix confirmed audio and worker leaks

### DIFF
--- a/providers/deepgram_stream.py
+++ b/providers/deepgram_stream.py
@@ -83,6 +83,10 @@ if TYPE_CHECKING:
     AsyncV1SocketClient = Any
 
 logger = logging.getLogger("pulsescribe")
+MIC_STREAM_CLOSE_TIMEOUT = 2.0
+_MIC_STREAM_CLOSE_LOCK = threading.Lock()
+_MIC_STREAM_CLOSE_THREAD: threading.Thread | None = None
+_MIC_STREAM_CLOSE_ERROR: Exception | None = None
 
 
 # =============================================================================
@@ -156,6 +160,14 @@ class StreamState:
     final_transcript_event: asyncio.Event = field(default_factory=asyncio.Event)
     # Flag für einmalige Buffer-Warnung
     buffer_overflow_logged: bool = False
+
+
+@dataclass
+class StopMechanism:
+    """Resources owned by the external stop-event bridge."""
+
+    shutdown_event: threading.Event = field(default_factory=threading.Event)
+    watcher_thread: threading.Thread | None = None
 
 
 @dataclass
@@ -810,6 +822,74 @@ def _stream_blocksize(sample_rate: int) -> int:
     return platform_audio_blocksize(sample_rate, default_blocksize)
 
 
+def _mic_stream_cleanup_is_stuck() -> bool:
+    global _MIC_STREAM_CLOSE_THREAD
+    with _MIC_STREAM_CLOSE_LOCK:
+        close_thread = _MIC_STREAM_CLOSE_THREAD
+        if close_thread is not None and not close_thread.is_alive():
+            _MIC_STREAM_CLOSE_THREAD = None
+            return _MIC_STREAM_CLOSE_ERROR is not None
+        return close_thread is not None or _MIC_STREAM_CLOSE_ERROR is not None
+
+
+def _close_mic_stream_bounded(stream: Any, session_id: str) -> bool:
+    """Close PortAudio without letting native deadlocks accumulate per retry."""
+    global _MIC_STREAM_CLOSE_ERROR, _MIC_STREAM_CLOSE_THREAD
+    with _MIC_STREAM_CLOSE_LOCK:
+        if _MIC_STREAM_CLOSE_ERROR is not None:
+            logger.error(f"[{session_id}] Vorheriger Mikrofon-Close ist fehlgeschlagen")
+            return False
+
+        existing = _MIC_STREAM_CLOSE_THREAD
+        if existing is not None:
+            if existing.is_alive():
+                logger.error(
+                    f"[{session_id}] Vorheriger Mikrofon-Cleanup hängt weiterhin"
+                )
+                return False
+            _MIC_STREAM_CLOSE_THREAD = None
+
+        def _close() -> None:
+            global _MIC_STREAM_CLOSE_ERROR
+            try:
+                stream.close()
+            except Exception as error:
+                with _MIC_STREAM_CLOSE_LOCK:
+                    _MIC_STREAM_CLOSE_ERROR = error
+                logger.debug(f"[{session_id}] Mikrofon-Close fehlgeschlagen: {error}")
+
+        close_thread = threading.Thread(
+            target=_close,
+            daemon=True,
+            name="DeepgramMicClose",
+        )
+        _MIC_STREAM_CLOSE_THREAD = close_thread
+        try:
+            # Publish and start atomically relative to cleanup-state readers.
+            close_thread.start()
+        except Exception as error:
+            if _MIC_STREAM_CLOSE_THREAD is close_thread:
+                _MIC_STREAM_CLOSE_THREAD = None
+            _MIC_STREAM_CLOSE_ERROR = error
+            logger.error(
+                f"[{session_id}] Mikrofon-Close-Thread konnte nicht starten: {error}"
+            )
+            return False
+    close_thread.join(timeout=MIC_STREAM_CLOSE_TIMEOUT)
+    if close_thread.is_alive():
+        logger.error(
+            f"[{session_id}] Mikrofon-Close hängt länger als "
+            f"{MIC_STREAM_CLOSE_TIMEOUT:g}s; weitere Streams werden verhindert"
+        )
+        return False
+
+    with _MIC_STREAM_CLOSE_LOCK:
+        if _MIC_STREAM_CLOSE_THREAD is close_thread:
+            _MIC_STREAM_CLOSE_THREAD = None
+        close_error = _MIC_STREAM_CLOSE_ERROR
+    return close_error is None
+
+
 def _create_mic_stream(
     callback: Callable[[np.ndarray, int, Any, Any], None],
     session_id: str,
@@ -830,6 +910,11 @@ def _create_mic_stream(
     import numpy as np
     import sounddevice as sd
 
+    if _mic_stream_cleanup_is_stuck():
+        raise RuntimeError(
+            "Vorheriger Mikrofon-Cleanup hängt; PulseScribe muss neu gestartet werden"
+        )
+
     input_device, sample_rate = get_input_device()
     blocksize = _stream_blocksize(sample_rate)
 
@@ -843,7 +928,13 @@ def _create_mic_stream(
         dtype=np.int16,
         callback=callback,
     )
-    mic_stream.start()
+    try:
+        mic_stream.start()
+    except Exception:
+        # InputStream has no reliable destructor for native PortAudio handles.
+        # Keep a potentially deadlocked close tracked and reject later streams.
+        _close_mic_stream_bounded(mic_stream, session_id)
+        raise
 
     logger.debug(f"[{session_id}] Audio-Device: {input_device}, {sample_rate}Hz")
 
@@ -1179,7 +1270,13 @@ def _init_warm_stream(
         daemon=True,
         name="WarmStreamForwarder",
     )
-    forwarder_thread.start()
+    try:
+        forwarder_thread.start()
+    except Exception:
+        warm_source.arm_event.clear()
+        if warm_source.drain_event is not None:
+            warm_source.drain_event.clear()
+        raise
 
     _log_init_complete(session_id, stream_start, "Warm-Stream armed", play_ready)
 
@@ -1507,31 +1604,26 @@ def _setup_stop_mechanism(
     session_id: str,
     *,
     stop_grace_seconds: "float | Callable[[], float]" = 0.0,
-) -> None:
-    """Richtet den Stop-Mechanismus ein.
+) -> StopMechanism:
+    """Richtet den Stop-Mechanismus ein und gibt dessen Ressourcen zurück.
 
     Unterstützte Modi:
     1. external_stop_event gesetzt: Thread überwacht das Event (alle Plattformen)
     2. Unix + Main-Thread: SIGUSR1 Signal-Handler
     3. Windows ohne external_stop_event: Warnung, da kein Stop-Mechanismus verfügbar
-
-    Args:
-        state: StreamState mit stop_event
-        loop: Event-Loop für thread-safe Aufrufe
-        external_stop_event: Externes threading.Event zum Stoppen
-        session_id: Session-ID für Logging
-        stop_grace_seconds: Zusätzliche Aufnahmezeit nach externem Stop-Signal.
-            Ein Callable wird erst NACH dem Stop-Signal ausgewertet (adaptiver
-            Stop-Tail: kurzer Nachlauf bei stillem Release, voller bei Sprache).
     """
+    mechanism = StopMechanism()
     if external_stop_event is not None:
-        # Unified-Daemon-Mode: Externes threading.Event überwachen
         def _watch_external_stop() -> None:
             external_stop_event.wait()
+            if mechanism.shutdown_event.is_set():
+                return
+
             grace_seconds = _resolve_stop_grace_seconds(stop_grace_seconds, session_id)
             if grace_seconds > 0:
                 logger.debug(f"[{session_id}] Stop-Grace: {grace_seconds:.2f}s")
-                time.sleep(grace_seconds)
+                if mechanism.shutdown_event.wait(timeout=grace_seconds):
+                    return
             try:
                 loop.call_soon_threadsafe(state.stop_event.set)
             except RuntimeError as e:
@@ -1539,38 +1631,48 @@ def _setup_stop_mechanism(
                     f"[{session_id}] Event-Loop geschlossen, Stop-Event nicht gesetzt: {e}"
                 )
 
-        stop_watcher = threading.Thread(
+        mechanism.watcher_thread = threading.Thread(
             target=_watch_external_stop, daemon=True, name="StopWatcher"
         )
-        stop_watcher.start()
+        mechanism.watcher_thread.start()
         logger.debug(f"[{session_id}] External stop event watcher gestartet")
 
     elif (
         sys.platform != "win32"
         and threading.current_thread() is threading.main_thread()
     ):
-        # Unix only: SIGUSR1 Signal-Handler
         import signal
 
         loop.add_signal_handler(signal.SIGUSR1, state.stop_event.set)
         logger.debug(f"[{session_id}] SIGUSR1 handler registriert")
 
     else:
-        # Windows ohne external_stop_event oder non-main thread
-        # In diesem Fall muss der Caller selbst für das Stoppen sorgen
-        # (z.B. durch direktes Setzen von state.stop_event)
         logger.warning(
             f"[{session_id}] Kein Stop-Mechanismus verfügbar. "
             f"Auf Windows muss external_stop_event gesetzt werden, "
             f"oder state.stop_event manuell gesetzt werden."
         )
+    return mechanism
 
 
 def _cleanup_stop_mechanism(
     loop: asyncio.AbstractEventLoop,
     external_stop_event: threading.Event | None,
+    mechanism: StopMechanism | None = None,
 ) -> None:
-    """Entfernt Signal-Handler (nur Unix)."""
+    """Stoppt den Event-Watcher und entfernt Unix-Signal-Handler."""
+    if mechanism is not None:
+        mechanism.shutdown_event.set()
+        if external_stop_event is not None:
+            # The supplied Event belongs to this session in both daemons. Setting
+            # it wakes the watcher immediately on internal/initialization errors.
+            external_stop_event.set()
+        watcher = mechanism.watcher_thread
+        if watcher is not None and watcher is not threading.current_thread():
+            watcher.join(timeout=1.0)
+            if watcher.is_alive():
+                logger.warning("StopWatcher reagiert nicht auf Session-Cleanup")
+
     if external_stop_event is None and sys.platform != "win32":
         if threading.current_thread() is threading.main_thread():
             import signal
@@ -1984,15 +2086,18 @@ async def _send_audio_to_deepgram(
 async def _listen_for_deepgram_messages(
     *,
     connection: AsyncV1SocketClient,
+    state: StreamState,
     session_id: str,
 ) -> None:
-    """Empfängt Transkripte von Deepgram."""
+    """Empfängt Transkripte von Deepgram und beendet die Session bei Fehlern."""
     try:
         await connection.start_listening()
     except asyncio.CancelledError:
         pass
     except Exception as e:
         logger.debug(f"[{session_id}] Listener beendet: {e}")
+        state.stream_error = e
+        state.stop_event.set()
 
 
 async def _stop_audio_source_before_shutdown(
@@ -2019,14 +2124,21 @@ def _cleanup_deepgram_audio_source(
     *,
     audio_result: AudioSourceResult,
     warm_stream_source: WarmStreamSource | None,
+    session_id: str,
 ) -> None:
     if audio_result.mic_stream is not None:
         try:
             if audio_result.mic_stream.active:
                 audio_result.mic_stream.stop()
-            audio_result.mic_stream.close()
         except Exception as e:
-            logger.debug(f"Mikrofon-Cleanup fehlgeschlagen: {e}")
+            logger.debug(f"Mikrofon-Stop beim Cleanup fehlgeschlagen: {e}")
+        _close_mic_stream_bounded(audio_result.mic_stream, session_id)
+
+    forwarder = audio_result.forwarder_thread
+    if forwarder is not None and forwarder is not threading.current_thread():
+        forwarder.join(timeout=FORWARDER_THREAD_JOIN_TIMEOUT)
+        if forwarder.is_alive():
+            logger.warning(f"[{session_id}] Forwarder-Thread reagiert nicht auf Cleanup")
 
     if warm_stream_source is None:
         return
@@ -2108,8 +2220,7 @@ async def deepgram_stream_core(
     loop = asyncio.get_running_loop()
     audio_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
 
-    # Stop-Mechanismus einrichten
-    _setup_stop_mechanism(
+    stop_mechanism = _setup_stop_mechanism(
         state,
         loop,
         external_stop_event,
@@ -2121,28 +2232,31 @@ async def deepgram_stream_core(
         ),
     )
 
-    # Audio-Source initialisieren (modus-spezifisch)
-    audio_result = _init_audio_source(
-        mode=mode,
-        early_buffer=early_buffer,
-        warm_stream_source=warm_stream_source,
-        state=state,
-        loop=loop,
-        audio_queue=audio_queue,
-        session_id=session_id,
-        play_ready=play_ready,
-        stream_start=stream_start,
-        audio_level_callback=audio_level_callback,
-    )
-    _emit_latency_event(
-        latency_event_callback,
-        "audio_stream_started",
-        elapsed_ms=round((time.perf_counter() - stream_start) * 1000, 3),
-    )
-
+    audio_result: AudioSourceResult | None = None
+    send_task: asyncio.Task[None] | None = None
+    listen_task: asyncio.Task[None] | None = None
     create_connection = connection_factory or _create_deepgram_connection
 
     try:
+        # Initialization belongs to the same lifecycle guard as the socket.
+        audio_result = _init_audio_source(
+            mode=mode,
+            early_buffer=early_buffer,
+            warm_stream_source=warm_stream_source,
+            state=state,
+            loop=loop,
+            audio_queue=audio_queue,
+            session_id=session_id,
+            play_ready=play_ready,
+            stream_start=stream_start,
+            audio_level_callback=audio_level_callback,
+        )
+        _emit_latency_event(
+            latency_event_callback,
+            "audio_stream_started",
+            elapsed_ms=round((time.perf_counter() - stream_start) * 1000, 3),
+        )
+
         async with create_connection(
             api_key,
             model=model,
@@ -2182,6 +2296,7 @@ async def deepgram_stream_core(
             listen_task = asyncio.create_task(
                 _listen_for_deepgram_messages(
                     connection=connection,
+                    state=state,
                     session_id=session_id,
                 )
             )
@@ -2216,13 +2331,26 @@ async def deepgram_stream_core(
             )
 
     finally:
-        _cleanup_deepgram_audio_source(
-            audio_result=audio_result,
-            warm_stream_source=warm_stream_source,
-        )
+        # Every exit path must wake the warm forwarder before its event loop closes.
+        state.stop_event.set()
 
-        # Signal-Handler entfernen
-        _cleanup_stop_mechanism(loop, external_stop_event)
+        pending_tasks = [
+            task
+            for task in (send_task, listen_task)
+            if task is not None and not task.done()
+        ]
+        for task in pending_tasks:
+            task.cancel()
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+        _cleanup_stop_mechanism(loop, external_stop_event, stop_mechanism)
+        if audio_result is not None:
+            _cleanup_deepgram_audio_source(
+                audio_result=audio_result,
+                warm_stream_source=warm_stream_source,
+                session_id=session_id,
+            )
 
     if state.stream_error:
         raise state.stream_error

--- a/providers/local.py
+++ b/providers/local.py
@@ -14,10 +14,10 @@ import platform
 import sys
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
+from concurrent.futures import Future, TimeoutError as FuturesTimeoutError
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any, Callable, Generator, Hashable
 
 from config import (
     DEFAULT_LOCAL_MODEL,
@@ -53,6 +53,65 @@ _LOCAL_VOCAB_KEYWORDS_MAX = 50
 _BACKENDS_WITHOUT_BEAM_SEARCH = ("mlx", "lightning")
 _LIGHTNING_WORKDIR_LOCK = threading.RLock()
 _NVIDIA_DLL_DIRECTORY_HANDLES: dict[str, object] = {}
+_CUDA_LOADS_LOCK = threading.Lock()
+_CUDA_LOAD_FUTURES: dict[Hashable, Future[Any]] = {}
+
+
+def _remove_completed_cuda_load(key: Hashable, future: Future[Any]) -> None:
+    with _CUDA_LOADS_LOCK:
+        if _CUDA_LOAD_FUTURES.get(key) is future:
+            _CUDA_LOAD_FUTURES.pop(key, None)
+
+
+def _run_cuda_load_with_timeout(
+    *,
+    key: Hashable,
+    loader: Callable[[], Any],
+) -> Any:
+    """Run one shared CUDA load per config in a process-exit-safe daemon thread.
+
+    Native CUDA calls cannot be cancelled safely. Sharing an in-flight Future
+    prevents retries from accumulating more stuck loaders, while a daemon thread
+    avoids the interpreter shutdown join imposed by ThreadPoolExecutor workers.
+    Completed results are removed immediately so abandoned loads do not retain a
+    model object after they eventually return.
+    """
+    with _CUDA_LOADS_LOCK:
+        future = _CUDA_LOAD_FUTURES.get(key)
+        if future is None:
+            future = Future()
+            _CUDA_LOAD_FUTURES[key] = future
+            future.add_done_callback(
+                lambda completed, load_key=key: _remove_completed_cuda_load(
+                    load_key, completed
+                )
+            )
+
+            def _load() -> None:
+                if not future.set_running_or_notify_cancel():
+                    return
+                try:
+                    result = loader()
+                except BaseException as error:
+                    future.set_exception(error)
+                else:
+                    future.set_result(result)
+
+            thread = threading.Thread(
+                target=_load,
+                daemon=True,
+                name="CudaModelLoader",
+            )
+            try:
+                thread.start()
+            except Exception:
+                # No worker owns this Future. Removing the registry reference is
+                # sufficient; cancelling here would execute the done callback
+                # synchronously while _CUDA_LOADS_LOCK is still held.
+                _CUDA_LOAD_FUTURES.pop(key, None)
+                raise
+
+    return future.result(timeout=CUDA_MODEL_LOAD_TIMEOUT)
 
 
 def _get_warmup_language() -> str:
@@ -589,18 +648,18 @@ class LocalProvider:
                 cpu_model._buffers["alignment_heads"] = heads  # type: ignore[arg-type]
 
     def _load_cuda_whisper_model(self, whisper, model_name: str):
-        executor = ThreadPoolExecutor(max_workers=1)
-        future = executor.submit(whisper.load_model, model_name, device=self._device)
+        device = self._device
         try:
-            return future.result(timeout=CUDA_MODEL_LOAD_TIMEOUT)
+            return _run_cuda_load_with_timeout(
+                key=("whisper", model_name, device),
+                loader=lambda: whisper.load_model(model_name, device=device),
+            )
         except FuturesTimeoutError:
             logger.warning(
                 f"CUDA Whisper Model-Loading Timeout ({CUDA_MODEL_LOAD_TIMEOUT}s) - "
                 "CPU-Fallback wird versucht."
             )
             raise RuntimeError("CUDA whisper model loading timeout")
-        finally:
-            executor.shutdown(wait=False, cancel_futures=True)
 
     def _load_whisper_cpu_fallback(self, whisper, model_name: str, error: Exception) -> str:
         if self._device == "cpu":
@@ -658,12 +717,17 @@ class LocalProvider:
 
             try:
                 if device == "cuda":
-                    # CUDA-Loading mit Timeout (kann bei cuDNN-Problemen hängen)
-                    executor = ThreadPoolExecutor(max_workers=1)
-                    future = executor.submit(_load_model, device, compute_type)
                     try:
-                        self._model_cache[cache_key] = future.result(
-                            timeout=CUDA_MODEL_LOAD_TIMEOUT
+                        self._model_cache[cache_key] = _run_cuda_load_with_timeout(
+                            key=(
+                                "faster",
+                                faster_name,
+                                device,
+                                compute_type,
+                                cpu_threads,
+                                num_workers,
+                            ),
+                            loader=lambda: _load_model(device, compute_type),
                         )
                     except FuturesTimeoutError:
                         logger.warning(
@@ -671,8 +735,6 @@ class LocalProvider:
                             "cuDNN hängt vermutlich. Fallback auf CPU."
                         )
                         raise RuntimeError("CUDA model loading timeout")
-                    finally:
-                        executor.shutdown(wait=False, cancel_futures=True)
                 else:
                     self._model_cache[cache_key] = _load_model(device, compute_type)
                 logger.info(f"Modell '{faster_name}' geladen ({device.upper()})")

--- a/pulsescribe_daemon.py
+++ b/pulsescribe_daemon.py
@@ -118,6 +118,8 @@ RESULT_POLL_INTERVAL_ACTIVE = 0.03
 RESULT_POLL_INTERVAL_BUSY = 0.06
 RESULT_POLL_INTERVAL_IDLE = 0.12
 RESULT_POLL_MAX_MESSAGES_PER_TICK = 250
+AUDIO_FINISHED_CALLBACK_TIMEOUT = 0.35
+AUDIO_CLOSE_TIMEOUT = 2.0
 RELOAD_ENV_SYNC_KEYS = (
     "PULSESCRIBE_HOTKEY",
     "PULSESCRIBE_HOTKEY_MODE",
@@ -324,6 +326,13 @@ class PulseScribeDaemon:
         self._audio_prewarm_lock = threading.Lock()
         self._audio_prewarm_started = False
         self._audio_prewarm_complete = threading.Event()
+        # Native PortAudio close() cannot be force-cancelled. Keep the helper
+        # tracked and block new capture while it is stuck, preventing one leaked
+        # native stream/thread per retry.
+        self._audio_close_lock = threading.Lock()
+        self._audio_close_thread: threading.Thread | None = None
+        self._audio_close_error: Exception | None = None
+        self._audio_close_failed = threading.Event()
 
     # =============================================================================
     # Thread-safe State Properties
@@ -502,7 +511,7 @@ class PulseScribeDaemon:
             self._worker_phase = phase
 
     def _mark_current_worker_abandoned(self, reason: str) -> None:
-        """Markiert den aktiven Worker als verloren, damit neue Runs wieder starten dürfen."""
+        """Markiert den aktiven Worker als verloren und verhindert stale Ergebnisse."""
         worker = self._worker_thread
         if worker is None or not worker.is_alive():
             return
@@ -2077,18 +2086,27 @@ class PulseScribeDaemon:
         effective_mode = run_mode_override or self.mode
 
         if self._worker_thread is not None and self._worker_thread.is_alive():
-            if not self._worker_abandoned:
+            if self._stop_event is not None:
+                self._stop_event.set()
+            if self._worker_abandoned:
+                logger.error(
+                    "Vorheriger Worker hängt weiterhin – neuer Run wird verhindert, "
+                    "damit sich keine Worker und Audiopuffer ansammeln "
+                    f"(phase={self._worker_phase}). Bitte PulseScribe neu starten."
+                )
+            else:
                 logger.warning(
                     "Worker-Thread läuft noch – Recording wird nicht neu gestartet "
                     f"(phase={self._worker_phase})"
                 )
-                if self._stop_event is not None:
-                    self._stop_event.set()
-                return
-            logger.warning(
-                "Vorheriger Worker hängt noch – starte neue Aufnahme mit frischem Run-Kontext "
-                f"(phase={self._worker_phase})"
+            return
+
+        if self._has_stuck_audio_close():
+            logger.error(
+                "PortAudio-Cleanup hängt weiterhin – neue Aufnahme wird verhindert. "
+                "Bitte PulseScribe neu starten."
             )
+            return
 
         # Modus-Entscheidung: Streaming vs. Recording
         use_streaming = effective_mode == "deepgram" and get_env_bool_default(
@@ -2260,22 +2278,28 @@ class PulseScribeDaemon:
         except queue.Full:
             pass
 
+    def _has_stuck_audio_close(self) -> bool:
+        """Return whether a tracked native close is still stuck."""
+        with self._audio_close_lock:
+            close_thread = self._audio_close_thread
+            if close_thread is not None and not close_thread.is_alive():
+                self._audio_close_thread = None
+                if self._audio_close_error is None:
+                    self._audio_close_failed.clear()
+            return self._audio_close_failed.is_set()
+
     def _shutdown_input_stream(
         self,
         stream,
         *,
         finished_event: threading.Event,
         run_id: int | None,
-    ) -> None:
-        """Beendet einen Input-Stream bevorzugt callback-gesteuert und ohne stop()-Blockade.
-
-        Für reine Aufnahme brauchen wir kein geordnetes Drain wie bei Playback.
-        Wenn der Callback nach gesetztem Stop-Event sauber mit CallbackAbort endet,
-        warten wir kurz auf finished_callback und schließen dann den inaktiven Stream.
-        Falls das nicht passiert, erzwingen wir abort()+close() in einem Helper-Thread.
-        """
+    ) -> bool:
+        """Close an input stream while containing unkillable PortAudio deadlocks."""
         self._set_worker_phase("recording:await-finished-callback", run_id=run_id)
-        finished_in_time = finished_event.wait(timeout=0.35)
+        finished_in_time = finished_event.wait(
+            timeout=AUDIO_FINISHED_CALLBACK_TIMEOUT
+        )
 
         def _close_stream() -> None:
             if not finished_in_time:
@@ -2294,8 +2318,9 @@ class PulseScribeDaemon:
                             pass
             try:
                 stream.close()
-            except Exception:
-                pass
+            except Exception as error:
+                with self._audio_close_lock:
+                    self._audio_close_error = error
 
         if not finished_in_time:
             logger.warning(
@@ -2303,17 +2328,53 @@ class PulseScribeDaemon:
             )
 
         self._set_worker_phase("recording:close-stream", run_id=run_id)
-        close_thread = threading.Thread(target=_close_stream, daemon=True)
-        close_thread.start()
-        close_thread.join(timeout=2.0)
+        with self._audio_close_lock:
+            existing = self._audio_close_thread
+            if existing is not None and existing.is_alive():
+                self._audio_close_failed.set()
+                logger.error("Bereits ein PortAudio-Close-Thread blockiert")
+                return False
+            close_thread = threading.Thread(
+                target=_close_stream,
+                daemon=True,
+                name="PortAudioClose",
+            )
+            self._audio_close_error = None
+            self._audio_close_thread = close_thread
+
+        try:
+            close_thread.start()
+        except Exception as error:
+            with self._audio_close_lock:
+                if self._audio_close_thread is close_thread:
+                    self._audio_close_thread = None
+                self._audio_close_error = error
+                self._audio_close_failed.set()
+            logger.error(f"PortAudio-Close-Thread konnte nicht starten: {error}")
+            return False
+        close_thread.join(timeout=AUDIO_CLOSE_TIMEOUT)
 
         if close_thread.is_alive():
+            self._audio_close_failed.set()
             logger.warning(
-                "Audio-Stream Timeout beim Schließen (2s) – "
-                "PortAudio-Deadlock vermutet, fahre fort ohne sauberes Schließen"
+                f"Audio-Stream Timeout beim Schließen ({AUDIO_CLOSE_TIMEOUT:g}s) – "
+                "PortAudio-Deadlock vermutet; weitere Aufnahmen werden verhindert"
             )
-        else:
-            logger.debug("Audio-Stream sauber geschlossen")
+            return False
+
+        with self._audio_close_lock:
+            if self._audio_close_thread is close_thread:
+                self._audio_close_thread = None
+            close_error = self._audio_close_error
+            if close_error is None:
+                self._audio_close_failed.clear()
+            else:
+                self._audio_close_failed.set()
+        if close_error is not None:
+            logger.error(f"Audio-Stream Close fehlgeschlagen: {close_error}")
+            return False
+        logger.debug("Audio-Stream sauber geschlossen")
+        return True
 
     def _streaming_worker(
         self,
@@ -2488,10 +2549,11 @@ class PulseScribeDaemon:
             stream.start()
         except Exception:
             if stream is not None:
-                try:
-                    stream.close()
-                except Exception:
-                    pass
+                self._shutdown_input_stream(
+                    stream,
+                    finished_event=finished_event,
+                    run_id=run_id,
+                )
             raise
 
         try:
@@ -3173,6 +3235,13 @@ class PulseScribeDaemon:
         self._stop_transcribing_watchdog()
         self._stop_error_reset_timer()
         self._cancel_local_warm_lifecycle(wait=True)
+
+        with self._audio_close_lock:
+            close_thread = self._audio_close_thread
+        if close_thread is not None and close_thread.is_alive():
+            close_thread.join(timeout=AUDIO_CLOSE_TIMEOUT)
+            if close_thread.is_alive():
+                logger.warning("PortAudio-Close-Thread hängt beim Shutdown weiterhin")
 
         # Provider-Cache leeren (Local Whisper kann ~500MB RAM halten)
         with self._provider_cache_lock:

--- a/pulsescribe_windows.py
+++ b/pulsescribe_windows.py
@@ -422,6 +422,13 @@ class PulseScribeWindows:
         # Provider-Cache (wichtig für LocalProvider - cached Modelle intern)
         self._provider_cache: dict[str, object] = {}
         self._provider_cache_lock = threading.Lock()
+        # Settings-Reloads dürfen höchstens einen Local-Preload-Worker besitzen.
+        # Bei Konfigurationsänderungen während eines laufenden Loads wird nur
+        # die jüngste Signatur für einen Folge-Durchlauf vorgemerkt.
+        self._local_preload_lock = threading.Lock()
+        self._local_preload_thread: threading.Thread | None = None
+        self._local_preload_active_signature: tuple[str | None, ...] | None = None
+        self._local_preload_pending_signature: tuple[str | None, ...] | None = None
 
         # Settings-Reload (FileWatcher + Polling-Fallback)
         self._env_observer = None
@@ -2663,7 +2670,7 @@ class PulseScribeWindows:
             self._invalidate_local_provider_runtime_config()
 
         if new_mode == "local":
-            threading.Thread(target=self._preload_local_model, daemon=True).start()
+            self._request_local_model_preload()
 
     def _invalidate_all_provider_runtime_configs(self) -> None:
         with self._provider_cache_lock:
@@ -2736,6 +2743,65 @@ class PulseScribeWindows:
         logger.info(f"Hotkeys geändert: toggle={new_toggle}, hold={new_hold}")
         self._restart_hotkey_listeners()
         return True
+
+    def _request_local_model_preload(self) -> bool:
+        """Start one coalescing preload worker for the latest local config."""
+        signature = self._local_provider_memory_signature()
+        with self._local_preload_lock:
+            if self._local_preload_thread is not None:
+                if signature != self._local_preload_active_signature:
+                    self._local_preload_pending_signature = signature
+                return False
+
+            self._local_preload_active_signature = signature
+            worker = threading.Thread(
+                target=self._run_local_model_preload_requests,
+                daemon=True,
+                name="LocalModelPreload",
+            )
+            self._local_preload_thread = worker
+
+        try:
+            worker.start()
+        except Exception:
+            with self._local_preload_lock:
+                if self._local_preload_thread is worker:
+                    self._local_preload_thread = None
+                    self._local_preload_active_signature = None
+            raise
+        return True
+
+    def _advance_local_model_preload(self, owner: threading.Thread) -> bool:
+        """Advance an owning preload thread to the latest queued signature."""
+        with self._local_preload_lock:
+            if self._local_preload_thread is not owner:
+                return False
+            pending = self._local_preload_pending_signature
+            self._local_preload_pending_signature = None
+            if pending is None or self._stop_event.is_set() or self.mode != "local":
+                self._local_preload_active_signature = None
+                self._local_preload_thread = None
+                return False
+            self._local_preload_active_signature = pending
+            return True
+
+    def _release_local_model_preload_owner(self, owner: threading.Thread) -> None:
+        with self._local_preload_lock:
+            if self._local_preload_thread is owner:
+                self._local_preload_active_signature = None
+                self._local_preload_pending_signature = None
+                self._local_preload_thread = None
+
+    def _run_local_model_preload_requests(self) -> None:
+        """Run the active preload and at most the latest changed request next."""
+        owner = threading.current_thread()
+        try:
+            while True:
+                self._preload_local_model()
+                if not self._advance_local_model_preload(owner):
+                    return
+        finally:
+            self._release_local_model_preload_owner(owner)
 
     def _preload_local_model(self):
         """Lädt Local-Model vor nach Settings-Änderung."""
@@ -3061,11 +3127,29 @@ class PulseScribeWindows:
     def _preload_local_model_for_prewarm(self) -> float:
         if self.mode != "local":
             return 0.0
+
+        signature = self._local_provider_memory_signature()
+        owner = threading.current_thread()
+        with self._local_preload_lock:
+            if self._local_preload_thread is not None:
+                if signature != self._local_preload_active_signature:
+                    self._local_preload_pending_signature = signature
+                return 0.0
+            self._local_preload_thread = owner
+            self._local_preload_active_signature = signature
+
+        preload_ms = 0.0
         try:
-            return self._run_local_model_prewarm()
-        except Exception as e:
-            logger.warning(f"Local-Modell Preload fehlgeschlagen: {e}")
-            return 0.0
+            try:
+                preload_ms = self._run_local_model_prewarm()
+            except Exception as e:
+                logger.warning(f"Local-Modell Preload fehlgeschlagen: {e}")
+
+            while self._advance_local_model_preload(owner):
+                self._preload_local_model()
+            return preload_ms
+        finally:
+            self._release_local_model_preload_owner(owner)
 
     def _run_local_model_prewarm(self) -> float:
         preload_start = time.perf_counter()

--- a/tests/test_daemon_mode.py
+++ b/tests/test_daemon_mode.py
@@ -732,7 +732,7 @@ class TestWatchdogTimer(unittest.TestCase):
         self.assertTrue(daemon._result_queue.empty())
 
     def test_watchdog_marks_alive_worker_abandoned(self):
-        """Ein Watchdog-Timeout muss festhängende Worker freigeben."""
+        """Ein Watchdog-Timeout muss späte Ergebnisse des Workers verwerfen."""
         daemon = PulseScribeDaemon(mode="local")
         daemon._current_state = AppState.TRANSCRIBING
         daemon._worker_phase = "recording:close-stream"
@@ -765,29 +765,25 @@ class TestWatchdogTimer(unittest.TestCase):
         daemon._stop_interim_polling.assert_called_once()
         daemon._stop_result_polling.assert_called_once()
 
-    def test_start_recording_recovers_from_abandoned_worker(self):
-        """Ein aufgegebener Alt-Worker darf neue Aufnahmen nicht dauerhaft blockieren."""
+    def test_start_recording_does_not_accumulate_abandoned_workers(self):
+        """Ein lebender Alt-Worker muss weitere Worker und Audiopuffer blockieren."""
         daemon = PulseScribeDaemon(mode="local")
         old_queue = daemon._result_queue
         daemon._worker_phase = "recording:close-stream"
         daemon._worker_abandoned = True
         daemon._worker_thread = MagicMock()
         daemon._worker_thread.is_alive.return_value = True
+        daemon._stop_event = threading.Event()
 
-        with (
-            patch("pulsescribe_daemon.threading.Thread") as mock_thread_cls,
-            patch("pulsescribe_daemon.INTERIM_FILE"),
-        ):
+        with patch("pulsescribe_daemon.threading.Thread") as mock_thread_cls:
             daemon._start_recording()
 
-        self.assertFalse(daemon._worker_abandoned)
-        self.assertTrue(daemon._recording)
-        self.assertIsNot(daemon._result_queue, old_queue)
-        self.assertEqual(daemon._current_state, AppState.LISTENING)
-        kwargs = mock_thread_cls.call_args.kwargs
-        self.assertEqual(kwargs["target"], daemon._recording_worker)
-        self.assertEqual(kwargs["name"], "RecordingWorker")
-        self.assertEqual(kwargs["args"][0], daemon._active_run_id)
+        self.assertTrue(daemon._worker_abandoned)
+        self.assertFalse(daemon._recording)
+        self.assertIs(daemon._result_queue, old_queue)
+        self.assertEqual(daemon._current_state, AppState.IDLE)
+        self.assertTrue(daemon._stop_event.is_set())
+        mock_thread_cls.assert_not_called()
 
 
 class TestAudioShutdown(unittest.TestCase):
@@ -817,6 +813,63 @@ class TestAudioShutdown(unittest.TestCase):
         daemon._shutdown_input_stream(stream, finished_event=finished_event, run_id=1)
 
         self.assertEqual(calls, ["abort", "close"])
+
+    def test_close_exception_blocks_additional_recordings(self):
+        daemon = PulseScribeDaemon(mode="local")
+        finished_event = threading.Event()
+        finished_event.set()
+        stream = MagicMock()
+        stream.close.side_effect = OSError("close failed")
+
+        closed = daemon._shutdown_input_stream(
+            stream,
+            finished_event=finished_event,
+            run_id=1,
+        )
+
+        self.assertFalse(closed)
+        self.assertTrue(daemon._has_stuck_audio_close())
+        with patch("pulsescribe_daemon.threading.Thread") as mock_thread_cls:
+            daemon._start_recording()
+        mock_thread_cls.assert_not_called()
+        self.assertFalse(daemon._recording)
+
+    def test_stuck_close_is_tracked_and_blocks_additional_recordings(self):
+        daemon = PulseScribeDaemon(mode="local")
+        finished_event = threading.Event()
+        finished_event.set()
+        release = threading.Event()
+
+        class _BlockingStream:
+            def close(self):
+                release.wait(timeout=1.0)
+
+        try:
+            with patch("pulsescribe_daemon.AUDIO_CLOSE_TIMEOUT", 0.01):
+                closed = daemon._shutdown_input_stream(
+                    _BlockingStream(),
+                    finished_event=finished_event,
+                    run_id=1,
+                )
+
+            self.assertFalse(closed)
+            self.assertTrue(daemon._has_stuck_audio_close())
+            close_thread = daemon._audio_close_thread
+            self.assertIsNotNone(close_thread)
+            self.assertTrue(close_thread.is_alive())
+
+            with patch("pulsescribe_daemon.threading.Thread") as mock_thread_cls:
+                daemon._start_recording()
+            mock_thread_cls.assert_not_called()
+            self.assertFalse(daemon._recording)
+        finally:
+            release.set()
+            close_thread = daemon._audio_close_thread
+            if close_thread is not None:
+                close_thread.join(timeout=1.0)
+
+        self.assertFalse(daemon._has_stuck_audio_close())
+        self.assertIsNone(daemon._audio_close_thread)
 
     def test_error_reset_timer_stored_on_enter_error(self):
         """_enter_error_state() speichert Timer-Referenz."""

--- a/tests/test_deepgram_stream.py
+++ b/tests/test_deepgram_stream.py
@@ -1657,7 +1657,7 @@ def test_empty_finalize_grace_ignores_finals_from_before_finalize(
     assert elapsed >= 0.18
 
 
-def test_stop_mechanism_resolves_callable_grace_at_stop_time(monkeypatch) -> None:
+def test_stop_mechanism_resolves_callable_grace_at_stop_time() -> None:
     """Ein Grace-Callable (adaptiver Stop-Tail) wird erst NACH dem Stop-Signal
     ausgewertet - nicht beim Setup der Session."""
     external_stop = threading.Event()
@@ -1690,16 +1690,8 @@ def test_stop_mechanism_resolves_callable_grace_at_stop_time(monkeypatch) -> Non
     assert resolver_calls == [True]
 
 
-def test_stop_mechanism_failing_grace_resolver_does_not_block_stop(
-    monkeypatch,
-) -> None:
+def test_stop_mechanism_failing_grace_resolver_does_not_block_stop() -> None:
     """Ein fehlschlagender Resolver darf den Stop nie verhindern (Grace 0)."""
-    sleep_calls: list[float] = []
-    monkeypatch.setattr(
-        deepgram_stream.time,
-        "sleep",
-        lambda seconds: sleep_calls.append(seconds),
-    )
 
     def broken_resolver() -> float:
         raise RuntimeError("resolver kaputt")
@@ -1720,5 +1712,3 @@ def test_stop_mechanism_failing_grace_resolver_does_not_block_stop(
         deepgram_stream._cleanup_stop_mechanism(loop, external_stop, mechanism)
 
     asyncio.run(_run())
-
-    assert sleep_calls == []

--- a/tests/test_deepgram_stream.py
+++ b/tests/test_deepgram_stream.py
@@ -413,31 +413,47 @@ def test_graceful_shutdown_sends_tail_padding_before_sentinel(monkeypatch) -> No
     assert sent_items == [b"last-audio", b"\x00\x00", None]
 
 
-def test_stop_mechanism_applies_configured_grace_before_stop(monkeypatch) -> None:
-    sleep_calls: list[float] = []
-    monkeypatch.setattr(
-        deepgram_stream.time,
-        "sleep",
-        lambda seconds: sleep_calls.append(seconds),
-    )
-
-    async def _run() -> None:
+def test_stop_mechanism_applies_configured_grace_before_stop() -> None:
+    async def _run() -> float:
         state = deepgram_stream.StreamState()
         external_stop = threading.Event()
-        deepgram_stream._setup_stop_mechanism(
+        loop = asyncio.get_running_loop()
+        mechanism = deepgram_stream._setup_stop_mechanism(
             state,
-            asyncio.get_running_loop(),
+            loop,
             external_stop,
             "sess",
-            stop_grace_seconds=0.3,
+            stop_grace_seconds=0.05,
         )
 
+        started = time.monotonic()
         external_stop.set()
         await asyncio.wait_for(state.stop_event.wait(), timeout=1.0)
+        elapsed = time.monotonic() - started
+        deepgram_stream._cleanup_stop_mechanism(loop, external_stop, mechanism)
+        return elapsed
 
-    asyncio.run(_run())
+    assert asyncio.run(_run()) >= 0.045
 
-    assert sleep_calls == [0.3]
+
+def test_stop_mechanism_cleanup_wakes_watcher_without_external_stop() -> None:
+    async def _run() -> bool:
+        state = deepgram_stream.StreamState()
+        external_stop = threading.Event()
+        loop = asyncio.get_running_loop()
+        mechanism = deepgram_stream._setup_stop_mechanism(
+            state,
+            loop,
+            external_stop,
+            "sess",
+        )
+        watcher = mechanism.watcher_thread
+        assert watcher is not None and watcher.is_alive()
+
+        deepgram_stream._cleanup_stop_mechanism(loop, external_stop, mechanism)
+        return watcher.is_alive()
+
+    assert asyncio.run(_run()) is False
 
 
 def test_finish_warm_forwarder_flushes_threadsafe_audio_before_sentinel() -> None:
@@ -475,6 +491,234 @@ def test_finish_warm_forwarder_flushes_threadsafe_audio_before_sentinel() -> Non
 
     assert items == [b"last-audio", None]
     assert join_timeout == deepgram_stream.FORWARDER_THREAD_JOIN_TIMEOUT
+
+
+def test_create_mic_stream_closes_native_stream_when_start_fails(monkeypatch) -> None:
+    class _FailingStream:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def start(self) -> None:
+            raise RuntimeError("start failed")
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    stream = _FailingStream()
+    monkeypatch.setattr(deepgram_stream, "get_input_device", lambda: (0, 16000))
+    monkeypatch.setattr(
+        deepgram_stream,
+        "create_low_latency_input_stream",
+        lambda *_args, **_kwargs: stream,
+    )
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        deepgram_stream._create_mic_stream(lambda *_args: None, "sess", 0.0)
+
+    assert stream.close_calls == 1
+
+
+def test_start_failure_with_stuck_close_blocks_additional_mic_streams(
+    monkeypatch,
+) -> None:
+    release = threading.Event()
+    close_started = threading.Event()
+    created_streams = 0
+
+    class _BlockingCloseStream:
+        def start(self) -> None:
+            raise RuntimeError("start failed")
+
+        def close(self) -> None:
+            close_started.set()
+            release.wait(timeout=1.0)
+
+    def create_stream(*_args, **_kwargs):
+        nonlocal created_streams
+        created_streams += 1
+        return _BlockingCloseStream()
+
+    monkeypatch.setattr(deepgram_stream, "get_input_device", lambda: (0, 16000))
+    monkeypatch.setattr(
+        deepgram_stream,
+        "create_low_latency_input_stream",
+        create_stream,
+    )
+    monkeypatch.setattr(deepgram_stream, "MIC_STREAM_CLOSE_TIMEOUT", 0.01)
+
+    try:
+        with pytest.raises(RuntimeError, match="start failed"):
+            deepgram_stream._create_mic_stream(lambda *_args: None, "sess", 0.0)
+        assert close_started.wait(timeout=1.0)
+        with pytest.raises(RuntimeError, match="Mikrofon-Cleanup hängt"):
+            deepgram_stream._create_mic_stream(lambda *_args: None, "sess", 0.0)
+        assert created_streams == 1
+    finally:
+        release.set()
+        close_thread = deepgram_stream._MIC_STREAM_CLOSE_THREAD
+        if close_thread is not None:
+            close_thread.join(timeout=1.0)
+        assert deepgram_stream._mic_stream_cleanup_is_stuck() is False
+
+
+def test_close_exception_blocks_additional_mic_streams(monkeypatch) -> None:
+    created_streams = 0
+
+    class _CloseFailingStream:
+        def start(self) -> None:
+            raise RuntimeError("start failed")
+
+        def close(self) -> None:
+            raise OSError("close failed")
+
+    def create_stream(*_args, **_kwargs):
+        nonlocal created_streams
+        created_streams += 1
+        return _CloseFailingStream()
+
+    monkeypatch.setattr(deepgram_stream, "get_input_device", lambda: (0, 16000))
+    monkeypatch.setattr(
+        deepgram_stream,
+        "create_low_latency_input_stream",
+        create_stream,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="start failed"):
+            deepgram_stream._create_mic_stream(lambda *_args: None, "sess", 0.0)
+        assert deepgram_stream._mic_stream_cleanup_is_stuck() is True
+        with pytest.raises(RuntimeError, match="Mikrofon-Cleanup hängt"):
+            deepgram_stream._create_mic_stream(lambda *_args: None, "sess", 0.0)
+        assert created_streams == 1
+    finally:
+        with deepgram_stream._MIC_STREAM_CLOSE_LOCK:
+            deepgram_stream._MIC_STREAM_CLOSE_THREAD = None
+            deepgram_stream._MIC_STREAM_CLOSE_ERROR = None
+
+
+def test_mic_close_thread_is_started_before_tracker_becomes_observable(
+    monkeypatch,
+) -> None:
+    start_entered = threading.Event()
+    allow_start = threading.Event()
+
+    class _DelayedStartThread:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self._alive = False
+
+        def start(self) -> None:
+            start_entered.set()
+            allow_start.wait(timeout=1.0)
+            self._alive = True
+
+        def join(self, timeout=None) -> None:
+            self._alive = False
+
+        def is_alive(self) -> bool:
+            return self._alive
+
+    monkeypatch.setattr(
+        deepgram_stream,
+        "threading",
+        SimpleNamespace(Thread=_DelayedStartThread),
+    )
+    owner = threading.Thread(
+        target=lambda: deepgram_stream._close_mic_stream_bounded(object(), "sess")
+    )
+
+    try:
+        owner.start()
+        assert start_entered.wait(timeout=1.0)
+        # Readers cannot observe the published-but-not-started Thread object.
+        assert not deepgram_stream._MIC_STREAM_CLOSE_LOCK.acquire(timeout=0.02)
+    finally:
+        allow_start.set()
+        owner.join(timeout=1.0)
+        with deepgram_stream._MIC_STREAM_CLOSE_LOCK:
+            deepgram_stream._MIC_STREAM_CLOSE_THREAD = None
+            deepgram_stream._MIC_STREAM_CLOSE_ERROR = None
+
+
+def test_warm_stream_thread_start_failure_disarms_source(monkeypatch) -> None:
+    warm_source = _make_warm_source([])
+
+    class _FailingThread:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def start(self) -> None:
+            raise RuntimeError("thread start failed")
+
+    monkeypatch.setattr(
+        deepgram_stream,
+        "threading",
+        SimpleNamespace(Thread=_FailingThread),
+    )
+
+    async def _run() -> None:
+        with pytest.raises(RuntimeError, match="thread start failed"):
+            deepgram_stream._init_warm_stream(
+                warm_source,
+                deepgram_stream.StreamState(),
+                asyncio.get_running_loop(),
+                asyncio.Queue(),
+                "sess",
+                False,
+                time.perf_counter(),
+            )
+
+    asyncio.run(_run())
+
+    assert warm_source.arm_event.is_set() is False
+    assert warm_source.drain_event is not None
+    assert warm_source.drain_event.is_set() is False
+
+
+def test_audio_cleanup_closes_stream_even_when_stop_fails() -> None:
+    class _StopFailingStream:
+        active = True
+
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def stop(self) -> None:
+            raise RuntimeError("stop failed")
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    stream = _StopFailingStream()
+    deepgram_stream._cleanup_deepgram_audio_source(
+        audio_result=deepgram_stream.AudioSourceResult(
+            sample_rate=16000,
+            mic_stream=cast(Any, stream),
+            buffer_state=None,
+        ),
+        warm_stream_source=None,
+        session_id="sess",
+    )
+
+    assert stream.close_calls == 1
+
+
+def test_listener_failure_stops_session() -> None:
+    class _FailingConnection:
+        async def start_listening(self) -> None:
+            raise OSError("listener failed")
+
+    async def _run() -> deepgram_stream.StreamState:
+        state = deepgram_stream.StreamState()
+        await deepgram_stream._listen_for_deepgram_messages(
+            connection=cast(Any, _FailingConnection()),
+            state=state,
+            session_id="sess",
+        )
+        return state
+
+    state = asyncio.run(_run())
+
+    assert isinstance(state.stream_error, OSError)
+    assert state.stop_event.is_set()
 
 
 def test_write_interim_text_replaces_file_atomically(tmp_path) -> None:
@@ -612,6 +856,9 @@ class _FakeWarmConnection:
     async def send_control(self, message) -> None:
         self.controls.append(message.type)
 
+    async def start_listening(self) -> None:
+        await asyncio.Future()
+
 
 class _FakeConnectionContext:
     def __init__(
@@ -679,6 +926,41 @@ def _install_fake_stream_core(
         return "warm result"
 
     monkeypatch.setattr(deepgram_stream, "deepgram_stream_core", fake_core)
+
+
+def test_core_connection_failure_reaps_stop_and_warm_forwarder_threads(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "test-key")
+    warm_source = _make_warm_source([])
+    external_stop = threading.Event()
+    baseline_thread_ids = {id(thread) for thread in threading.enumerate()}
+
+    @deepgram_stream.asynccontextmanager
+    async def failing_connection_factory(_api_key: str, **_kwargs):
+        raise OSError("connect failed")
+        yield  # pragma: no cover
+
+    with pytest.raises(OSError, match="connect failed"):
+        asyncio.run(
+            deepgram_stream.deepgram_stream_core(
+                "nova-3",
+                "de",
+                play_ready=False,
+                external_stop_event=external_stop,
+                warm_stream_source=warm_source,
+                connection_factory=failing_connection_factory,
+            )
+        )
+
+    leaked_lifecycle_threads = [
+        thread
+        for thread in threading.enumerate()
+        if id(thread) not in baseline_thread_ids
+        and thread.name in {"StopWatcher", "WarmStreamForwarder"}
+        and thread.is_alive()
+    ]
+    assert leaked_lifecycle_threads == []
 
 
 def test_deepgram_stream_core_uses_injected_connection_factory(monkeypatch) -> None:
@@ -1378,13 +1660,6 @@ def test_empty_finalize_grace_ignores_finals_from_before_finalize(
 def test_stop_mechanism_resolves_callable_grace_at_stop_time(monkeypatch) -> None:
     """Ein Grace-Callable (adaptiver Stop-Tail) wird erst NACH dem Stop-Signal
     ausgewertet - nicht beim Setup der Session."""
-    sleep_calls: list[float] = []
-    monkeypatch.setattr(
-        deepgram_stream.time,
-        "sleep",
-        lambda seconds: sleep_calls.append(seconds),
-    )
-
     external_stop = threading.Event()
     resolver_calls: list[bool] = []
 
@@ -1395,9 +1670,10 @@ def test_stop_mechanism_resolves_callable_grace_at_stop_time(monkeypatch) -> Non
 
     async def _run() -> None:
         state = deepgram_stream.StreamState()
-        deepgram_stream._setup_stop_mechanism(
+        loop = asyncio.get_running_loop()
+        mechanism = deepgram_stream._setup_stop_mechanism(
             state,
-            asyncio.get_running_loop(),
+            loop,
             external_stop,
             "sess",
             stop_grace_seconds=adaptive_grace,
@@ -1407,11 +1683,11 @@ def test_stop_mechanism_resolves_callable_grace_at_stop_time(monkeypatch) -> Non
 
         external_stop.set()
         await asyncio.wait_for(state.stop_event.wait(), timeout=1.0)
+        deepgram_stream._cleanup_stop_mechanism(loop, external_stop, mechanism)
 
     asyncio.run(_run())
 
     assert resolver_calls == [True]
-    assert sleep_calls == [0.05]
 
 
 def test_stop_mechanism_failing_grace_resolver_does_not_block_stop(
@@ -1431,15 +1707,17 @@ def test_stop_mechanism_failing_grace_resolver_does_not_block_stop(
     async def _run() -> None:
         state = deepgram_stream.StreamState()
         external_stop = threading.Event()
-        deepgram_stream._setup_stop_mechanism(
+        loop = asyncio.get_running_loop()
+        mechanism = deepgram_stream._setup_stop_mechanism(
             state,
-            asyncio.get_running_loop(),
+            loop,
             external_stop,
             "sess",
             stop_grace_seconds=broken_resolver,
         )
         external_stop.set()
         await asyncio.wait_for(state.stop_event.wait(), timeout=1.0)
+        deepgram_stream._cleanup_stop_mechanism(loop, external_stop, mechanism)
 
     asyncio.run(_run())
 

--- a/tests/test_local_provider.py
+++ b/tests/test_local_provider.py
@@ -91,6 +91,89 @@ class TestImportHelpers:
             local_mod._NVIDIA_DLL_DIRECTORY_HANDLES.update(original_handles)
 
 
+class TestCudaLoadLifecycle:
+    def test_thread_start_failure_does_not_deadlock_cuda_registry(self, monkeypatch):
+        import providers.local as local_mod
+
+        class _FailingThread:
+            def __init__(self, *_args, **_kwargs) -> None:
+                pass
+
+            def start(self) -> None:
+                raise RuntimeError("thread unavailable")
+
+        with monkeypatch.context() as scoped:
+            scoped.setattr(
+                local_mod,
+                "threading",
+                SimpleNamespace(Thread=_FailingThread),
+            )
+            with pytest.raises(RuntimeError, match="thread unavailable"):
+                local_mod._run_cuda_load_with_timeout(
+                    key=("whisper", "start-failure", "cuda"),
+                    loader=object,
+                )
+
+        assert ("whisper", "start-failure", "cuda") not in local_mod._CUDA_LOAD_FUTURES
+        assert local_mod._CUDA_LOADS_LOCK.acquire(timeout=0.1)
+        local_mod._CUDA_LOADS_LOCK.release()
+
+    def test_timeout_reuses_one_daemon_loader_and_releases_completed_result(
+        self, monkeypatch
+    ):
+        import providers.local as local_mod
+
+        release = threading.Event()
+        finished = threading.Event()
+        load_calls = 0
+        load_calls_lock = threading.Lock()
+        baseline_thread_ids = {id(thread) for thread in threading.enumerate()}
+
+        class _BlockingWhisper:
+            @staticmethod
+            def load_model(_model_name, *, device):
+                nonlocal load_calls
+                assert device == "cuda"
+                with load_calls_lock:
+                    load_calls += 1
+                try:
+                    release.wait(timeout=2.0)
+                    return object()
+                finally:
+                    finished.set()
+
+        first_provider = local_mod.LocalProvider()
+        first_provider._device = "cuda"
+        second_provider = local_mod.LocalProvider()
+        second_provider._device = "cuda"
+        monkeypatch.setattr(local_mod, "CUDA_MODEL_LOAD_TIMEOUT", 0.01)
+
+        try:
+            with pytest.raises(RuntimeError, match="CUDA whisper model loading timeout"):
+                first_provider._load_cuda_whisper_model(_BlockingWhisper, "tiny")
+            with pytest.raises(RuntimeError, match="CUDA whisper model loading timeout"):
+                second_provider._load_cuda_whisper_model(_BlockingWhisper, "tiny")
+
+            active_loaders = [
+                thread
+                for thread in threading.enumerate()
+                if id(thread) not in baseline_thread_ids
+                and thread.name == "CudaModelLoader"
+                and thread.is_alive()
+            ]
+            assert load_calls == 1
+            assert len(active_loaders) == 1
+            assert active_loaders[0].daemon is True
+        finally:
+            release.set()
+            assert finished.wait(timeout=1.0)
+            for thread in threading.enumerate():
+                if id(thread) not in baseline_thread_ids:
+                    thread.join(timeout=1.0)
+
+        assert ("whisper", "tiny", "cuda") not in local_mod._CUDA_LOAD_FUTURES
+
+
 class TestLightningModelMapping:
     """Tests für Lightning Model-Name Mapping."""
 

--- a/tests/test_windows_race_conditions.py
+++ b/tests/test_windows_race_conditions.py
@@ -931,6 +931,107 @@ def test_reload_settings_releases_local_provider_on_mode_change(monkeypatch):
     assert "local" not in daemon._provider_cache
 
 
+def test_local_reload_coalesces_preload_threads_for_unchanged_settings():
+    windows_module = _load_windows_module()
+    daemon = windows_module.PulseScribeWindows(
+        mode="local",
+        streaming=False,
+        overlay=False,
+    )
+    release = threading.Event()
+    started = threading.Event()
+    preload_calls = 0
+    preload_calls_lock = threading.Lock()
+
+    def blocked_preload() -> None:
+        nonlocal preload_calls
+        with preload_calls_lock:
+            preload_calls += 1
+        started.set()
+        release.wait(timeout=2.0)
+
+    daemon._preload_local_model = blocked_preload
+    signature = daemon._local_provider_memory_signature()
+    baseline_thread_ids = {id(thread) for thread in threading.enumerate()}
+
+    try:
+        for _ in range(5):
+            daemon._apply_mode_reload_settings(
+                {"PULSESCRIBE_MODE": "local"},
+                old_local_signature=signature,
+            )
+
+        assert started.wait(timeout=1.0)
+        active_preloads = [
+            thread
+            for thread in threading.enumerate()
+            if id(thread) not in baseline_thread_ids
+            and thread.name == "LocalModelPreload"
+            and thread.is_alive()
+        ]
+        assert preload_calls == 1
+        assert len(active_preloads) == 1
+    finally:
+        release.set()
+        worker = daemon._local_preload_thread
+        if worker is not None:
+            worker.join(timeout=1.0)
+
+    assert daemon._local_preload_thread is None
+
+
+def test_startup_prewarm_and_reload_share_one_preload_owner(monkeypatch):
+    windows_module = _load_windows_module()
+    daemon = windows_module.PulseScribeWindows(
+        mode="local",
+        streaming=False,
+        overlay=False,
+    )
+    startup_started = threading.Event()
+    release_startup = threading.Event()
+    signatures = [("local", "model-a")]
+    reload_preload_calls = 0
+
+    def startup_prewarm() -> float:
+        startup_started.set()
+        release_startup.wait(timeout=2.0)
+        return 25.0
+
+    def reload_preload() -> None:
+        nonlocal reload_preload_calls
+        reload_preload_calls += 1
+
+    monkeypatch.setattr(
+        daemon,
+        "_local_provider_memory_signature",
+        lambda: signatures[0],
+    )
+    daemon._run_local_model_prewarm = startup_prewarm
+    daemon._preload_local_model = reload_preload
+    startup_thread = threading.Thread(
+        target=daemon._preload_local_model_for_prewarm,
+        name="StartupPrewarm",
+    )
+
+    try:
+        startup_thread.start()
+        assert startup_started.wait(timeout=1.0)
+        signatures[0] = ("local", "model-b")
+
+        assert daemon._request_local_model_preload() is False
+        assert daemon._local_preload_thread is startup_thread
+        assert not any(
+            thread.name == "LocalModelPreload" and thread.is_alive()
+            for thread in threading.enumerate()
+        )
+    finally:
+        release_startup.set()
+        startup_thread.join(timeout=1.0)
+
+    assert reload_preload_calls == 1
+    assert daemon._local_preload_thread is None
+
+
 def test_reload_settings_releases_local_provider_on_memory_setting_change(monkeypatch):
     windows_module = _load_windows_module()
     daemon = windows_module.PulseScribeWindows(


### PR DESCRIPTION
## Summary
- make Deepgram watcher, forwarder, async tasks, and native microphone cleanup lifecycle-safe
- coalesce CUDA/model preload workers and contain unkillable native close failures
- prevent abandoned macOS workers and PortAudio cleanup retries from accumulating resources
- add regression coverage for failure, timeout, and concurrency paths

## Validation
- `pytest -q` — 1408 passed, 6 skipped
- `python -m pyright` — 0 errors
- `ruff check .`
- `git diff --check`

## Review
Independent fresh-context code review completed; no open Critical/High/Medium findings.

## Summary by Sourcery

Harden Deepgram streaming, local provider, and daemon lifecycles to avoid leaked threads, native audio handles, and stuck workers, and add regression tests for these failure modes.

Bug Fixes:
- Ensure Deepgram external stop watcher threads and signal handlers are cleaned up reliably and do not leak on session failures.
- Guarantee microphone streams are closed even when start/stop fail and prevent new streams if PortAudio cleanup is stuck or erroneous.
- Stop Deepgram sessions when the listener fails so downstream code sees the error and terminates the stream.
- Prevent daemon recording from starting when a previous worker or audio-close helper is still stuck, avoiding accumulation of workers and buffers.
- Coalesce local model CUDA loads into shared daemon threads per configuration to avoid piling up unkillable loader threads on timeouts.
- Ensure local mode settings reloads share at most one preload worker and reuse the startup prewarm owner, preventing multiple concurrent preload threads.

Enhancements:
- Introduce explicit tracking structures for stop mechanisms, microphone close helpers, and local preload workers to make lifecycle state observable and controllable.
- Refine watchdog semantics so abandoned workers are marked in a way that suppresses late results rather than restarting recording automatically.

Tests:
- Add extensive tests around Deepgram stop mechanism cleanup, warm stream forwarder failures, listener error handling, and microphone cleanup edge cases.
- Add daemon-mode tests covering stuck PortAudio close behavior, recording blocking when cleanup fails, and updated watchdog semantics.
- Add local provider tests validating CUDA load lifecycle behavior, including thread start failures, shared loader timeouts, and registry cleanup.
- Add Windows-specific tests ensuring local reload coalesces preload threads and startup prewarm and reload share a single preload owner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recording shutdown reliability, including protection against stuck audio resources and overlapping recording attempts.
  - Sessions now stop cleanly when audio or connection errors occur.
  - Prevented late results from failed or timed-out recording workers.
  - Improved microphone startup and cleanup after failures.

- **Performance & Reliability**
  - Local model loading and preloading now avoid duplicate work during repeated requests or settings changes.
  - Added safer handling for model-loading timeouts, CUDA errors, and startup interruptions.
  - Improved stream stop timing and cleanup behavior for more responsive shutdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->