### PR TITLE
Release PulseScribe v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-04
+
 ### Added
 
 - **Windows: adaptive stop tail** – when the audio tail was already silent for
@@ -18,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Audio and streaming lifecycle leaks** – Deepgram stop watchers, warm-stream
+  forwarders, sender/listener tasks, and native microphone streams are now
+  terminated or closed on initialization, connection, listener, stop, and
+  cancellation failures. PortAudio close deadlocks remain tracked and block
+  unsafe retry accumulation until the app is restarted.
+- **Abandoned worker accumulation on macOS** – watchdog-abandoned recording
+  workers can no longer be replaced while still alive, preventing retained
+  audio buffers, provider calls, and native resources from growing per retry.
+- **CUDA and local preload worker accumulation** – timed-out CUDA loads are
+  deduplicated in process-exit-safe daemon workers, while Windows startup and
+  settings reloads share one coalescing local-model preload owner.
 - **Deepgram SDK pinned to 5.x** – `deepgram-sdk` 7.x removed the 5.x module
   paths the streaming provider relies on (`deepgram.extensions.types.sockets`
   for `ListenV1ControlMessage`), silently breaking KeepAlive/Finalize/

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,0 +1,66 @@
+**Release Date:** 2026-08-04
+
+## Highlights
+
+PulseScribe 1.3.0 improves long-running stability and makes dictation feel
+faster, especially on Windows. The release addresses the confirmed audio,
+worker, and model-loading lifecycle leaks, prevents unkillable native failures
+from accumulating further resources, and adds regression coverage for their
+failure, timeout, and concurrency paths.
+
+### Lifecycle and Memory Safety
+
+- Deepgram `StopWatcher` and warm-stream forwarder threads are stopped on every
+  exit path, including microphone initialization and WebSocket connection
+  failures.
+- Deepgram sender/listener tasks are cancelled and awaited; listener failures
+  now stop the session instead of leaving capture active.
+- Native microphone streams are closed independently after stop failures.
+  PortAudio close hangs and close errors are tracked so retries cannot accumulate
+  additional native streams or helper threads.
+- macOS no longer starts another recording worker while a watchdog-abandoned
+  worker is still alive, preventing retained audio buffers and provider calls
+  from accumulating.
+- Timed-out CUDA model loads are deduplicated in daemon workers and no longer
+  block interpreter shutdown through `ThreadPoolExecutor` cleanup.
+- Windows startup and settings reloads share one coalescing local-model preload
+  owner instead of spawning overlapping preload threads.
+
+### Faster Windows Dictation
+
+- `snappy` is now the default Windows latency preset.
+- Adaptive stop tails shorten the post-release capture window when speech has
+  already ended while preserving the full tail for mid-word releases.
+- Hotkeys can retrigger immediately after a complete release cycle.
+- Clipboard verification replaces the fixed paste delay and obeys a hard timeout.
+- Hotkey actions and tray updates run outside the low-level keyboard callback.
+- A best-effort responsiveness boost enables 1 ms timer resolution and
+  above-normal process priority.
+
+### Deepgram Reliability
+
+- Empty-finalize grace exits as soon as a late final transcript arrives.
+- `deepgram-sdk` is pinned to the compatible 5.x API required by streaming
+  control messages.
+
+## Validation
+
+- 1,408 tests passed; 6 platform-specific tests skipped locally.
+- macOS and Windows GitHub Actions checks passed.
+- Pyright and Ruff completed without errors.
+- Independent and automated reviews found no unresolved high-priority issues.
+
+## Installation
+
+Download the available package from the GitHub release page, or install from the
+source archive. Existing users can update in place; configuration under
+`~/.pulsescribe/` is preserved.
+
+For platform-specific build instructions, see:
+
+- [Building on macOS](../BUILDING_MACOS.md)
+- [Building on Windows](../BUILDING_WINDOWS.md)
+
+## Full Changelog
+
+See [CHANGELOG.md](../../CHANGELOG.md) for the complete list of changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pulsescribe"
-version = "1.2.0"
+version = "1.3.0"
 description = "Spracheingabe für macOS und Windows – Transkription mit OpenAI Whisper, Deepgram, Groq oder lokal"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- bump project version to 1.3.0
- promote the accumulated Unreleased changelog entries
- add v1.3.0 release notes highlighting lifecycle leak fixes and Windows latency improvements

## Validation
- `pytest -q` — 1408 passed, 6 skipped
- `python -m pyright` — 0 errors
- `ruff check .`
- `python -m build --wheel` — METADATA version 1.3.0
- `git diff --check`

## Release plan
After checks and automated review pass, merge to `master`, create annotated tag `v1.3.0`, and publish the GitHub release from `docs/releases/v1.3.0.md`.

## Summary by Sourcery

Prepare the 1.3.0 release of PulseScribe with updated versioning and documented changes.

New Features:
- Add PulseScribe 1.3.0 release notes documenting stability and latency improvements, especially on Windows.

Enhancements:
- Promote accumulated Unreleased changelog entries into a dated 1.3.0 section highlighting lifecycle, memory, and latency improvements.

Build:
- Bump the project package version from 1.2.0 to 1.3.0 in pyproject.toml for the 1.3.0 release.

Documentation:
- Add detailed docs/releases/v1.3.0.md release notes covering lifecycle safety fixes, Windows dictation performance, Deepgram reliability, validation, installation, and links to platform build guides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Faster Windows dictation shutdown through adaptive stop-tail handling.
  - Improved Deepgram streaming reliability.

- **Bug Fixes**
  - Reduced resource accumulation in audio, recording, streaming, and local-model workflows.
  - Improved CUDA preload stability.

- **Documentation**
  - Added PulseScribe 1.3.0 release notes, installation guidance, validation results, and changelog details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->