### PR TITLE
CI: add opt-in Local Whisper installer

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -43,6 +43,11 @@ on:
         required: true
         default: false
         type: boolean
+      build_windows_local:
+        description: Build and optionally publish the large Local Whisper installer
+        required: true
+        default: false
+        type: boolean
 
 concurrency:
   group: installers-${{ github.event.release.tag_name || inputs.tag || github.event.pull_request.number || github.ref }}
@@ -61,11 +66,13 @@ jobs:
       commit: ${{ steps.release.outputs.commit }}
       publish: ${{ steps.release.outputs.publish }}
       clobber: ${{ steps.release.outputs.clobber }}
+      build_windows_local: ${{ steps.release.outputs.build_windows_local }}
     env:
       REQUESTED_REF: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag || github.event.pull_request.head.sha }}
       PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
       UPLOAD_TO_RELEASE: ${{ inputs.upload_to_release || 'false' }}
       REPLACE_EXISTING_ASSETS: ${{ inputs.replace_existing_assets || 'false' }}
+      BUILD_WINDOWS_LOCAL: ${{ inputs.build_windows_local || 'false' }}
 
     steps:
       - name: Check out requested ref
@@ -124,11 +131,15 @@ jobs:
 
           publish=false
           clobber=false
+          build_windows_local=false
           if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
             publish=true
           elif [[ "$UPLOAD_TO_RELEASE" == "true" ]]; then
             publish=true
             clobber="$REPLACE_EXISTING_ASSETS"
+          fi
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$BUILD_WINDOWS_LOCAL" == "true" ]]; then
+            build_windows_local=true
           fi
 
           {
@@ -137,6 +148,7 @@ jobs:
             echo "commit=$head_commit"
             echo "publish=$publish"
             echo "clobber=$clobber"
+            echo "build_windows_local=$build_windows_local"
           } >> "$GITHUB_OUTPUT"
 
           {
@@ -146,6 +158,7 @@ jobs:
             echo "- Version: \`$version\`"
             echo "- Commit: \`$head_commit\`"
             echo "- Upload to release: \`$publish\`"
+            echo "- Local Whisper installer: \`$build_windows_local\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   build-macos:
@@ -371,10 +384,138 @@ jobs:
           compression-level: 0
           retention-days: 14
 
+  build-windows-local:
+    name: Build Windows installer (Local Whisper)
+    needs: metadata
+    if: needs.metadata.outputs.build_windows_local == 'true'
+    runs-on: windows-2022
+    timeout-minutes: 180
+    env:
+      VERSION: ${{ needs.metadata.outputs.version }}
+      RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+      RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
+
+    steps:
+      - name: Check out validated release commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.metadata.outputs.commit }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install Local Whisper build dependencies
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt "pyinstaller>=6,<7" "PySide6>=6,<7"
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: |
+          $knownPaths = @(
+            "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe",
+            "${env:ProgramFiles}\Inno Setup 6\ISCC.exe"
+          )
+          if (-not (Get-Command iscc -ErrorAction SilentlyContinue) -and
+              -not ($knownPaths | Where-Object { Test-Path $_ })) {
+            choco install innosetup --no-progress --yes
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to install Inno Setup"
+            }
+          }
+
+      - name: Build Local Whisper installer
+        shell: pwsh
+        run: ./build_windows.ps1 -Clean -Installer -Local
+
+      - name: Validate Local Whisper installer
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $installer = "dist\PulseScribe-Setup-$env:VERSION-Local.exe"
+          if (-not (Test-Path $installer -PathType Leaf)) {
+            throw "Missing installer: $installer"
+          }
+
+          $file = Get-Item $installer
+          if ($file.Length -le 0) {
+            throw "Installer is empty: $installer"
+          }
+          $expectedFileVersion = "$env:VERSION.0"
+          $actualFileVersion = $file.VersionInfo.FileVersion.Trim()
+          if ($actualFileVersion -ne $expectedFileVersion) {
+            throw "Installer file version '$actualFileVersion' does not match '$expectedFileVersion'"
+          }
+
+          $bundleRoot = "dist\PulseScribe"
+          foreach ($packageDirectory in @("_internal\faster_whisper", "_internal\ctranslate2", "_internal\torch")) {
+            $path = Join-Path $bundleRoot $packageDirectory
+            if (-not (Test-Path $path -PathType Container)) {
+              throw "Local Whisper package missing from build: $path"
+            }
+          }
+
+          $archivePath = "dist\PulseScribe-Setup-$env:VERSION-Local.zip"
+          $maximumReleaseAssetBytes = 1900MB
+          if ($file.Length -ge $maximumReleaseAssetBytes) {
+            throw "Local installer is $($file.Length) bytes and exceeds the $maximumReleaseAssetBytes-byte release budget"
+          }
+
+          $hash = (Get-FileHash -Path $installer -Algorithm SHA256).Hash.ToLowerInvariant()
+          Set-Content -Path "$installer.sha256" -Value "$hash  $($file.Name)" -Encoding utf8
+
+          if (Test-Path $archivePath) {
+            Remove-Item -Force $archivePath
+          }
+          Compress-Archive -Path $installer -DestinationPath $archivePath -CompressionLevel NoCompression
+
+          $archive = Get-Item $archivePath
+          $maximumReleaseAssetBytes = 1900MB
+          if ($archive.Length -gt $maximumReleaseAssetBytes) {
+            throw "Local installer archive is $($archive.Length) bytes and exceeds the $maximumReleaseAssetBytes-byte release budget"
+          }
+
+          $archiveHash = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+          Set-Content -Path "$archivePath.sha256" -Value "$archiveHash  $($archive.Name)" -Encoding utf8
+
+      - name: Record Local Whisper build environment
+        shell: pwsh
+        run: |
+          @(
+            "tag=$env:RELEASE_TAG"
+            "commit=$env:RELEASE_COMMIT"
+            "version=$env:VERSION"
+            "variant=local-whisper"
+            "runner=$([System.Environment]::OSVersion.VersionString)"
+            "python=$(python --version 2>&1)"
+            "pyinstaller=$(python -m PyInstaller --version)"
+            ""
+            $(python -m pip freeze)
+          ) | Set-Content -Path dist\build-metadata-windows-local.txt -Encoding utf8
+
+      - name: Upload Local Whisper build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: PulseScribe-Windows-Local-${{ needs.metadata.outputs.version }}
+          path: |
+            dist/PulseScribe-Setup-${{ needs.metadata.outputs.version }}-Local.zip
+            dist/PulseScribe-Setup-${{ needs.metadata.outputs.version }}-Local.zip.sha256
+            dist/PulseScribe-Setup-${{ needs.metadata.outputs.version }}-Local.exe.sha256
+            dist/build-metadata-windows-local.txt
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+
   publish-release:
     name: Attach installers to GitHub release
-    needs: [metadata, build-macos, build-windows]
-    if: needs.metadata.outputs.publish == 'true'
+    needs: [metadata, build-macos, build-windows, build-windows-local]
+    if: needs.metadata.outputs.publish == 'true' && (always() && !failure() && !cancelled())
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -383,6 +524,7 @@ jobs:
       RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
       VERSION: ${{ needs.metadata.outputs.version }}
       CLOBBER: ${{ needs.metadata.outputs.clobber }}
+      LOCAL_INSTALLER: ${{ needs.metadata.outputs.build_windows_local }}
 
     steps:
       - name: Download installer artifacts
@@ -403,10 +545,16 @@ jobs:
 
           (
             cd release-assets
-            sha256sum \
-              "PulseScribe-${VERSION}.dmg" \
-              "PulseScribe-Setup-${VERSION}.exe" \
-              > SHA256SUMS.txt
+            assets=(
+              "PulseScribe-${VERSION}.dmg"
+              "PulseScribe-Setup-${VERSION}.exe"
+            )
+            if [[ "$LOCAL_INSTALLER" == "true" ]]; then
+              local_installer="PulseScribe-Setup-${VERSION}-Local.zip"
+              [[ -s "$local_installer" ]]
+              assets+=("$local_installer")
+            fi
+            sha256sum "${assets[@]}" > SHA256SUMS.txt
           )
 
       - name: Upload assets to existing release
@@ -420,6 +568,9 @@ jobs:
             "release-assets/PulseScribe-Setup-${VERSION}.exe"
             "release-assets/SHA256SUMS.txt"
           )
+          if [[ "${LOCAL_INSTALLER:-false}" == "true" ]]; then
+            files+=("release-assets/PulseScribe-Setup-${VERSION}-Local.zip")
+          fi
 
           if [[ "$CLOBBER" != "true" ]]; then
             existing="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -476,7 +476,6 @@ jobs:
           Compress-Archive -Path $installer -DestinationPath $archivePath -CompressionLevel NoCompression
 
           $archive = Get-Item $archivePath
-          $maximumReleaseAssetBytes = 1900MB
           if ($archive.Length -gt $maximumReleaseAssetBytes) {
             throw "Local installer archive is $($archive.Length) bytes and exceeds the $maximumReleaseAssetBytes-byte release budget"
           }

--- a/docs/BUILDING_WINDOWS.md
+++ b/docs/BUILDING_WINDOWS.md
@@ -66,8 +66,26 @@ Existing assets are not overwritten by default. Add
 replaced deliberately.
 
 The CI installer is currently unsigned and may trigger a Windows SmartScreen
-warning. The multi-gigabyte Local variant remains a manual, opt-in build; normal
-release CI publishes the recommended API-only installer.
+warning. The multi-gigabyte Local variant is an explicit opt-in manual build so
+normal PRs and releases do not spend CI time and storage on it.
+
+To build and publish the Local Whisper variant for an existing release, run:
+
+```powershell
+gh workflow run build-installers.yml `
+  -f tag=v1.3.0 `
+  -f upload_to_release=true `
+  -f replace_existing_assets=true `
+  -f build_windows_local=true
+```
+
+This refreshes the standard installers and `SHA256SUMS.txt`, then uploads the
+Local installer as `PulseScribe-Setup-{version}-Local.zip` alongside them. GitHub
+release assets are limited to 2 GiB, so the workflow verifies the uploaded ZIP
+stays within the release budget. The temporary workflow artifact also contains
+the unpacked EXE hash for verification after extraction. Without
+`upload_to_release=true`, the Local installer is kept only as that temporary
+workflow artifact.
 
 ## Build Output
 
@@ -102,7 +120,7 @@ dist/
 | Variant | Command | Size | Description |
 |---------|---------|------|-------------|
 | **API-only** (default) | `.\build_windows.ps1 -Installer` | ~30 MB | Cloud APIs only (Deepgram, OpenAI, Groq) |
-| **Local** | `.\build_windows.ps1 -Installer -Local` | ~4 GB | Includes faster-whisper for offline use |
+| **Local** | `.\build_windows.ps1 -Installer -Local` | >1.5 GB | Includes faster-whisper for offline use |
 
 > **Note:** The `-Local` variant includes `faster-whisper`, `torch`, and `ctranslate2` for local transcription.
 


### PR DESCRIPTION
## Summary
- add an explicit manual `build_windows_local` opt-in for the large Windows Local Whisper installer
- validate local backend packaging, installer version, release-size budget, and checksums
- publish the Local installer as a size-compatible ZIP alongside the standard assets when explicitly requested
- keep normal release and PR installer builds unchanged when the Local job is skipped
- document the v1.3.0 publishing command and the 2 GiB release-asset constraint

## Validation
- `actionlint`
- workflow metadata simulation for a manual Local build
- `pytest -q` — 1408 passed, 6 skipped
- `python -m pyright` — 0 errors
- `ruff check .`
- `git diff --check`
- independent fresh-context review, including follow-up fixes for skipped-job publishing and GitHub asset-size limits

## After merge
Run `build-installers.yml` for `v1.3.0` with `upload_to_release=true`, `replace_existing_assets=true`, and `build_windows_local=true` to refresh standard assets and publish the Local ZIP.

## Summary by Sourcery

Add an explicit opt-in workflow path to build and publish a large Windows Local Whisper installer while keeping default installer builds unchanged.

New Features:
- Introduce a build_windows_local input and metadata flag to trigger a dedicated Windows Local Whisper installer job.
- Add CI logic to package the Local Whisper Windows installer as a ZIP release asset with checksum files when explicitly requested.

Enhancements:
- Update release publishing to conditionally include the Local Whisper ZIP in SHA256SUMS and release uploads without affecting standard assets.
- Document the manual workflow invocation for publishing the Local Whisper installer and clarify GitHub release asset size constraints.

CI:
- Extend the build-installers workflow with a separate Windows Local Whisper job that validates packaging, installer version, contents, and size budget before uploading artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Windows Local Whisper installer build for manually triggered workflows.
  * Installer packages now include checksums, validation results, and build metadata.
  * The installer can be uploaded as a release asset when enabled.

* **Documentation**
  * Updated Windows build instructions with workflow options, asset details, validation checks, and revised size estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->